### PR TITLE
Use application-wide coroutine scope

### DIFF
--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Application.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Application.kt
@@ -6,6 +6,8 @@ import com.bookingbot.api.DatabaseFactory
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
+import io.ktor.server.application.ApplicationStopped
+import com.bookingbot.gateway.ApplicationScope
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.contentnegotiation.*
@@ -87,4 +89,9 @@ fun Application.module() {
 
     // Запускаем бота вместе с сервером
     startTelegramBot()
+
+    // Отменяем все корутины при остановке приложения
+    environment.monitor.subscribe(ApplicationStopped) {
+        ApplicationScope.cancel()
+    }
 }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/ApplicationScope.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/ApplicationScope.kt
@@ -1,0 +1,19 @@
+package com.bookingbot.gateway
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Application-wide CoroutineScope used instead of GlobalScope.
+ */
+object ApplicationScope : CoroutineScope {
+    private val job = SupervisorJob()
+    override val coroutineContext: CoroutineContext = Dispatchers.Default + job
+
+    /** Cancel all coroutines launched in [ApplicationScope]. */
+    fun cancel() {
+        job.cancel()
+    }
+}

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/broadcastHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/broadcastHandler.kt
@@ -12,7 +12,7 @@ import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
 import com.github.kotlintelegrambot.extensions.filters.Filter
-import kotlinx.coroutines.GlobalScope
+import com.bookingbot.gateway.ApplicationScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -72,7 +72,7 @@ fun addBroadcastHandler(dispatcher: Dispatcher, userService: UserService) {
                 var failCount = 0
 
                 // Запускаем рассылку в отдельной корутине, чтобы не блокировать бота
-                GlobalScope.launch {
+                ApplicationScope.launch {
                     userIds.forEach { userId ->
                         try {
                             // Используем forwardMessage, чтобы сохранить форматирование, фото и т.д.


### PR DESCRIPTION
## Summary
- introduce `ApplicationScope` to manage coroutines
- cancel all application coroutines on server shutdown
- replace `GlobalScope.launch` in broadcast handler

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68840825a2948321a9ed65f518a49d72