### PR TITLE
Centralize callback strings

### DIFF
--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminActionHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminActionHandler.kt
@@ -6,6 +6,7 @@ import com.github.kotlintelegrambot.dispatcher.Dispatcher
 import com.github.kotlintelegrambot.dispatcher.callbackQuery
 import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.ParseMode
+import com.bookingbot.gateway.util.CallbackData
 
 fun addAdminActionHandler(dispatcher: Dispatcher, bookingService: BookingService, clubService: ClubService) {
     // Этот обработчик "слушает" нажатия на все inline-кнопки, которые видит бот
@@ -17,8 +18,8 @@ fun addAdminActionHandler(dispatcher: Dispatcher, bookingService: BookingService
 
         when {
             // Если callback_data начинается с "admin_confirm_"
-            data.startsWith("admin_confirm_") -> {
-                val bookingId = data.removePrefix("admin_confirm_").toInt()
+            data.startsWith(CallbackData.ADMIN_CONFIRM_PREFIX) -> {
+                val bookingId = data.removePrefix(CallbackData.ADMIN_CONFIRM_PREFIX).toInt()
                 // Обновляем статус брони в базе данных на "SEATED" (гости пришли)
                 bookingService.updateBookingStatus(bookingId, "SEATED")
 
@@ -35,8 +36,8 @@ fun addAdminActionHandler(dispatcher: Dispatcher, bookingService: BookingService
             }
 
             // Если callback_data начинается с "admin_noshow_"
-            data.startsWith("admin_noshow_") -> {
-                val bookingId = data.removePrefix("admin_noshow_").toInt()
+            data.startsWith(CallbackData.ADMIN_NOSHOW_PREFIX) -> {
+                val bookingId = data.removePrefix(CallbackData.ADMIN_NOSHOW_PREFIX).toInt()
                 // Обновляем статус брони в базе данных на "NO_SHOW" (неявка)
                 bookingService.updateBookingStatus(bookingId, "NO_SHOW")
 
@@ -50,8 +51,8 @@ fun addAdminActionHandler(dispatcher: Dispatcher, bookingService: BookingService
                 bot.answerCallbackQuery(callbackQuery.id, text = "Статус обновлен: Неявка.")
             }
 
-            data.startsWith("admin_cancel_") -> {
-                val bookingId = data.removePrefix("admin_cancel_").toInt()
+            data.startsWith(CallbackData.ADMIN_CANCEL_PREFIX) -> {
+                val bookingId = data.removePrefix(CallbackData.ADMIN_CANCEL_PREFIX).toInt()
                 val bookingToCancel = bookingService.findBookingById(bookingId) // Находим бронь перед отменой
 
                 if (bookingToCancel != null && bookingService.cancelBookingByStaff(bookingId)) {

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminDashboardHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminDashboardHandler.kt
@@ -8,13 +8,14 @@ import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.ParseMode
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+import com.bookingbot.gateway.util.CallbackData
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 fun addAdminDashboardHandler(dispatcher: Dispatcher, userService: UserService, bookingService: BookingService) {
 
     // Обработчик для кнопки "Управление бронями"
-    dispatcher.callbackQuery("admin_manage_bookings") {
+    dispatcher.callbackQuery(CallbackData.ADMIN_MANAGE_BOOKINGS) {
         val adminId = callbackQuery.from.id
         val chatId = ChatId.fromId(adminId)
 
@@ -46,9 +47,9 @@ fun addAdminDashboardHandler(dispatcher: Dispatcher, userService: UserService, b
             // Кнопки для управления бронью (те же, что и в канале)
             val adminKeyboard = InlineKeyboardMarkup.create(
                 listOf(
-                    InlineKeyboardButton.CallbackData("✅ Пришли", "admin_confirm_${booking.id}"),
-                    InlineKeyboardButton.CallbackData("❌ Неявка", "admin_noshow_${booking.id}"),
-                    InlineKeyboardButton.CallbackData("🚫 Отменить", "admin_cancel_${booking.id}")
+                    InlineKeyboardButton.CallbackData("✅ Пришли", "${CallbackData.ADMIN_CONFIRM_PREFIX}${booking.id}"),
+                    InlineKeyboardButton.CallbackData("❌ Неявка", "${CallbackData.ADMIN_NOSHOW_PREFIX}${booking.id}"),
+                    InlineKeyboardButton.CallbackData("🚫 Отменить", "${CallbackData.ADMIN_CANCEL_PREFIX}${booking.id}")
                 )
             )
 

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminHandlers.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminHandlers.kt
@@ -7,6 +7,7 @@ import com.bookingbot.gateway.Bot
 import com.bookingbot.gateway.fsm.State
 import com.bookingbot.gateway.fsm.StateStorage
 import com.bookingbot.gateway.util.StateFilter
+import com.bookingbot.gateway.util.CallbackData
 import com.github.kotlintelegrambot.dispatcher.Dispatcher
 import com.github.kotlintelegrambot.dispatcher.command
 import com.github.kotlintelegrambot.dispatcher.message
@@ -202,7 +203,7 @@ fun addAdminHandlers(dispatcher: Dispatcher, userService: UserService, clubServi
         // <<< НАЧАЛО: Перенаправляем на стандартный флоу выбора клуба
         val clubs = clubService.getAllClubs()
         val clubButtons = clubs.map {
-            InlineKeyboardButton.CallbackData(it.name, "show_club_${it.id}")
+            InlineKeyboardButton.CallbackData(it.name, "${CallbackData.SHOW_CLUB_PREFIX}${it.id}")
         }.chunked(2)
 
         bot.sendMessage(

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/broadcastHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/broadcastHandler.kt
@@ -5,6 +5,7 @@ import com.bookingbot.api.services.UserService
 import com.bookingbot.gateway.fsm.State
 import com.bookingbot.gateway.fsm.StateStorage
 import com.bookingbot.gateway.util.StateFilter
+import com.bookingbot.gateway.util.CallbackData
 import com.github.kotlintelegrambot.dispatcher.Dispatcher
 import com.github.kotlintelegrambot.dispatcher.callbackQuery
 import com.github.kotlintelegrambot.dispatcher.message
@@ -19,7 +20,7 @@ import kotlinx.coroutines.launch
 fun addBroadcastHandler(dispatcher: Dispatcher, userService: UserService) {
 
     // Шаг 1: Админ нажимает "Создать рассылку"
-    dispatcher.callbackQuery("admin_create_broadcast") {
+    dispatcher.callbackQuery(CallbackData.ADMIN_CREATE_BROADCAST) {
         val adminId = callbackQuery.from.id
         val admin = userService.findOrCreateUser(adminId, null)
 
@@ -41,8 +42,8 @@ fun addBroadcastHandler(dispatcher: Dispatcher, userService: UserService) {
 
         val userCount = userService.getAllUserIds().size
         val confirmationKeyboard = InlineKeyboardMarkup.create(listOf(
-            InlineKeyboardButton.CallbackData("✅ Отправить всем ($userCount чел.)", "broadcast_confirm_send"),
-            InlineKeyboardButton.CallbackData("❌ Отмена", "broadcast_cancel")
+            InlineKeyboardButton.CallbackData("✅ Отправить всем ($userCount чел.)", CallbackData.BROADCAST_CONFIRM_SEND),
+            InlineKeyboardButton.CallbackData("❌ Отмена", CallbackData.BROADCAST_CANCEL)
         ))
 
         StateStorage.setState(adminId, State.BroadcastConfirmation)
@@ -58,7 +59,7 @@ fun addBroadcastHandler(dispatcher: Dispatcher, userService: UserService) {
         val messageIdToForward = context.broadcastMessageId
 
         when (callbackQuery.data) {
-            "broadcast_confirm_send" -> {
+            CallbackData.BROADCAST_CONFIRM_SEND -> {
                 if (messageIdToForward == null) {
                     bot.sendMessage(ChatId.fromId(adminId), "Ошибка: не найдено сообщение для рассылки.")
                     StateStorage.clear(adminId)
@@ -91,7 +92,7 @@ fun addBroadcastHandler(dispatcher: Dispatcher, userService: UserService) {
                     bot.sendMessage(ChatId.fromId(adminId), "✅ Рассылка завершена.\nУспешно: $successCount\nНе удалось: $failCount")
                 }
             }
-            "broadcast_cancel" -> {
+            CallbackData.BROADCAST_CANCEL -> {
                 bot.editMessageText(ChatId.fromId(adminId), callbackQuery.message!!.messageId, text = "Рассылка отменена.")
             }
         }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/clubInfoHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/clubInfoHandler.kt
@@ -5,13 +5,18 @@ import com.bookingbot.api.services.EventService
 import com.bookingbot.api.services.TableService
 import com.github.kotlintelegrambot.dispatcher.Dispatcher
 import com.github.kotlintelegrambot.dispatcher.callbackQuery
+import com.bookingbot.gateway.util.CallbackData
 import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.ParseMode
 import java.time.format.DateTimeFormatter
 import java.time.ZoneId
 
 fun addClubInfoHandler(dispatcher: Dispatcher, clubService: ClubService, tableService: TableService, eventService: EventService) {
-    val specificPrefixes = listOf("club_info_", "club_photos_", "club_events_")
+    val specificPrefixes = listOf(
+        CallbackData.CLUB_INFO_PREFIX,
+        CallbackData.CLUB_PHOTOS_PREFIX,
+        CallbackData.CLUB_EVENTS_PREFIX
+    )
 
     dispatcher.callbackQuery {
         val data = callbackQuery.data
@@ -20,8 +25,8 @@ fun addClubInfoHandler(dispatcher: Dispatcher, clubService: ClubService, tableSe
         val chatId = ChatId.fromId(callbackQuery.message!!.chat.id)
 
         when {
-            data.startsWith("club_info_") -> {
-                val clubId = data.removePrefix("club_info_").toIntOrNull() ?: return@callbackQuery
+            data.startsWith(CallbackData.CLUB_INFO_PREFIX) -> {
+                val clubId = data.removePrefix(CallbackData.CLUB_INFO_PREFIX).toIntOrNull() ?: return@callbackQuery
                 val club = clubService.findClubById(clubId)
 
                 if (club != null) {
@@ -53,11 +58,11 @@ fun addClubInfoHandler(dispatcher: Dispatcher, clubService: ClubService, tableSe
                     bot.sendMessage(chatId, text = "Информация о клубе не найдена.")
                 }
             }
-            data.startsWith("club_photos_") -> {
+            data.startsWith(CallbackData.CLUB_PHOTOS_PREFIX) -> {
                 bot.answerCallbackQuery(callbackQuery.id, text = "Раздел 'Фотоотчеты' в разработке.", showAlert = true)
             }
-            data.startsWith("club_events_") -> {
-                val clubId = data.removePrefix("club_events_").toIntOrNull() ?: return@callbackQuery
+            data.startsWith(CallbackData.CLUB_EVENTS_PREFIX) -> {
+                val clubId = data.removePrefix(CallbackData.CLUB_EVENTS_PREFIX).toIntOrNull() ?: return@callbackQuery
                 val events = eventService.findUpcomingEventsByClub(clubId)
 
                 if (events.isEmpty()) {

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/contentHandlers.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/contentHandlers.kt
@@ -6,18 +6,19 @@ import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.ParseMode
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+import com.bookingbot.gateway.util.CallbackData
 
 fun addContentHandlers(dispatcher: Dispatcher) {
 
     // Обработчик для кнопки "Музыка"
-    dispatcher.callbackQuery("music_sets") {
+    dispatcher.callbackQuery(CallbackData.MUSIC_SETS) {
         val chatId = ChatId.fromId(callbackQuery.message!!.chat.id)
 
         // Заглушка: в будущем этот список можно будет брать из БД
         val musicSets = listOf(
-            "DJ Proton - Live @ Cosmos (July 2025)" to "play_set_1",
-            "DJ Neutron - Summer Mix" to "play_set_2",
-            "DJ Electron - Night Vibes" to "play_set_3"
+            "DJ Proton - Live @ Cosmos (July 2025)" to "${CallbackData.PLAY_SET_PREFIX}1",
+            "DJ Neutron - Summer Mix" to "${CallbackData.PLAY_SET_PREFIX}2",
+            "DJ Electron - Night Vibes" to "${CallbackData.PLAY_SET_PREFIX}3"
         )
 
         val musicButtons = musicSets.map { (title, callbackData) ->
@@ -33,16 +34,16 @@ fun addContentHandlers(dispatcher: Dispatcher) {
 
     // Обработчик для выбора конкретного сета
     dispatcher.callbackQuery {
-        if (!callbackQuery.data.startsWith("play_set_")) return@callbackQuery
+        if (!callbackQuery.data.startsWith(CallbackData.PLAY_SET_PREFIX)) return@callbackQuery
 
         val chatId = ChatId.fromId(callbackQuery.message!!.chat.id)
         val setId = callbackQuery.data
 
         // Заглушка со ссылками
         val musicLinks = mapOf(
-            "play_set_1" to "https://soundcloud.com/example/dj-proton-live",
-            "play_set_2" to "https://www.youtube.com/watch?v=example2",
-            "play_set_3" to "https://soundcloud.com/example/dj-electron-vibes"
+            "${CallbackData.PLAY_SET_PREFIX}1" to "https://soundcloud.com/example/dj-proton-live",
+            "${CallbackData.PLAY_SET_PREFIX}2" to "https://www.youtube.com/watch?v=example2",
+            "${CallbackData.PLAY_SET_PREFIX}3" to "https://soundcloud.com/example/dj-electron-vibes"
         )
 
         val link = musicLinks[setId]

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/myBookingsHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/myBookingsHandler.kt
@@ -9,12 +9,13 @@ import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.ParseMode
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+import com.bookingbot.gateway.util.CallbackData
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 fun addMyBookingsHandler(dispatcher: Dispatcher, bookingService: BookingService, clubService: ClubService) {
     // Обработчик для кнопки "Мои бронирования"
-    dispatcher.callbackQuery("my_bookings") {
+    dispatcher.callbackQuery(CallbackData.MY_BOOKINGS) {
         val chatId = ChatId.fromId(callbackQuery.message!!.chat.id)
         val bookings = bookingService.findBookingsByUserId(chatId.id)
 
@@ -41,8 +42,8 @@ fun addMyBookingsHandler(dispatcher: Dispatcher, bookingService: BookingService,
             val bookingMenu = if (booking.status != "CANCELLED") {
                 InlineKeyboardMarkup.create(
                     listOf(
-                        InlineKeyboardButton.CallbackData("Изменить", "edit_booking_${booking.id}"),
-                        InlineKeyboardButton.CallbackData("Отменить", "cancel_booking_${booking.id}")
+                        InlineKeyboardButton.CallbackData("Изменить", "${CallbackData.EDIT_BOOKING_PREFIX}${booking.id}"),
+                        InlineKeyboardButton.CallbackData("Отменить", "${CallbackData.CANCEL_BOOKING_PREFIX}${booking.id}")
                     )
                 )
             } else {
@@ -65,11 +66,11 @@ fun addMyBookingsHandler(dispatcher: Dispatcher, bookingService: BookingService,
         val userId = callbackQuery.from.id
 
         when {
-            data.startsWith("edit_booking_") -> {
+            data.startsWith(CallbackData.EDIT_BOOKING_PREFIX) -> {
                 bot.answerCallbackQuery(callbackQuery.id, text = "Функция изменения пока не реализована.", showAlert = true)
             }
-            data.startsWith("cancel_booking_") -> {
-                val bookingId = data.removePrefix("cancel_booking_").toIntOrNull()
+            data.startsWith(CallbackData.CANCEL_BOOKING_PREFIX) -> {
+                val bookingId = data.removePrefix(CallbackData.CANCEL_BOOKING_PREFIX).toIntOrNull()
                 if (bookingId == null) {
                     bot.answerCallbackQuery(callbackQuery.id, "Ошибка: неверный ID брони.", showAlert = true)
                     return@callbackQuery

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/navigationHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/navigationHandler.kt
@@ -4,6 +4,7 @@ import com.bookingbot.api.model.UserRole
 import com.bookingbot.api.services.UserService
 import com.bookingbot.gateway.fsm.StateStorage
 import com.bookingbot.gateway.markup.Menus
+import com.bookingbot.gateway.util.CallbackData
 import com.github.kotlintelegrambot.dispatcher.Dispatcher
 import com.github.kotlintelegrambot.dispatcher.callbackQuery
 import com.github.kotlintelegrambot.dispatcher.command
@@ -21,7 +22,7 @@ fun addNavigationHandler(dispatcher: Dispatcher, userService: UserService) {
     }
 
     // Обработчик для inline-кнопки "Главное меню"
-    dispatcher.callbackQuery("back_to_main_menu") {
+    dispatcher.callbackQuery(CallbackData.BACK_TO_MAIN_MENU) {
         val userId = callbackQuery.from.id
         val message = callbackQuery.message ?: return@callbackQuery
         StateStorage.clear(userId)

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/promoterDashboardHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/promoterDashboardHandler.kt
@@ -5,6 +5,7 @@ import com.bookingbot.api.services.ClubService
 import com.bookingbot.gateway.util.escapeMarkdownV2 // <<< ДОБАВЛЕН ИМПОРТ
 import com.github.kotlintelegrambot.dispatcher.Dispatcher
 import com.github.kotlintelegrambot.dispatcher.callbackQuery
+import com.bookingbot.gateway.util.CallbackData
 import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.ParseMode
 import java.time.ZoneId
@@ -13,7 +14,7 @@ import java.time.format.DateTimeFormatter
 fun addPromoterDashboardHandler(dispatcher: Dispatcher, bookingService: BookingService, clubService: ClubService) {
 
     // Обработчик для кнопки "Мои брони (промо)"
-    dispatcher.callbackQuery("promoter_my_bookings") {
+    dispatcher.callbackQuery(CallbackData.PROMOTER_MY_BOOKINGS) {
         val promoterId = callbackQuery.from.id
         val chatId = ChatId.fromId(promoterId)
 

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/promoterHandlers.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/promoterHandlers.kt
@@ -12,12 +12,13 @@ import com.github.kotlintelegrambot.dispatcher.message
 import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+import com.bookingbot.gateway.util.CallbackData
 import com.github.kotlintelegrambot.extensions.filters.Filter
 
 fun addPromoterHandlers(dispatcher: Dispatcher, userService: UserService, clubService: ClubService) {
 
     // Шаг 1: Промоутер нажимает "Бронь для гостя"
-    dispatcher.callbackQuery("promoter_start_booking") {
+    dispatcher.callbackQuery(CallbackData.PROMOTER_START_BOOKING) {
         val promoterId = callbackQuery.from.id
         val promoter = userService.findOrCreateUser(promoterId, callbackQuery.from.username)
 
@@ -50,7 +51,7 @@ fun addPromoterHandlers(dispatcher: Dispatcher, userService: UserService, clubSe
         // Перенаправляем промоутера на стандартный флоу выбора клуба
         val clubs = clubService.getAllClubs()
         val clubButtons = clubs.map {
-            InlineKeyboardButton.CallbackData(it.name, "show_club_${it.id}")
+            InlineKeyboardButton.CallbackData(it.name, "${CallbackData.SHOW_CLUB_PREFIX}${it.id}")
         }.chunked(2)
 
         bot.sendMessage(

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/markup/CalendarKeyboard.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/markup/CalendarKeyboard.kt
@@ -2,6 +2,7 @@ package com.bookingbot.gateway.markup
 
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+import com.bookingbot.gateway.util.CallbackData
 import java.time.LocalDate
 import java.time.YearMonth
 import java.time.format.TextStyle
@@ -22,16 +23,16 @@ object CalendarKeyboard {
         val monthName = yearMonth.month.getDisplayName(TextStyle.FULL_STANDALONE, locale)
         keyboard.add(
             listOf(
-                InlineKeyboardButton.CallbackData("◀", "calendar_prev_${yearMonth}"),
-                InlineKeyboardButton.CallbackData("$monthName $year", "calendar_ignore"),
-                InlineKeyboardButton.CallbackData("▶", "calendar_next_${yearMonth}")
+                InlineKeyboardButton.CallbackData("◀", "${CallbackData.CALENDAR_PREV_PREFIX}${yearMonth}"),
+                InlineKeyboardButton.CallbackData("$monthName $year", CallbackData.CALENDAR_IGNORE),
+                InlineKeyboardButton.CallbackData("▶", "${CallbackData.CALENDAR_NEXT_PREFIX}${yearMonth}")
             )
         )
 
         // 2. Дни недели
         keyboard.add(
             listOf("Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс").map {
-                InlineKeyboardButton.CallbackData(it, "calendar_ignore")
+                InlineKeyboardButton.CallbackData(it, CallbackData.CALENDAR_IGNORE)
             }
         )
 
@@ -41,7 +42,7 @@ object CalendarKeyboard {
 
         // Добавляем пустые кнопки для смещения
         repeat(dayOfWeekOffset) {
-            calendarDays.add(InlineKeyboardButton.CallbackData(" ", "calendar_ignore"))
+            calendarDays.add(InlineKeyboardButton.CallbackData(" ", CallbackData.CALENDAR_IGNORE))
         }
 
         // Добавляем кнопки с числами
@@ -49,9 +50,9 @@ object CalendarKeyboard {
             val date = yearMonth.atDay(day)
             // Не даем выбрать прошедшие даты
             if (date.isBefore(LocalDate.now())) {
-                calendarDays.add(InlineKeyboardButton.CallbackData(" ", "calendar_ignore"))
+                calendarDays.add(InlineKeyboardButton.CallbackData(" ", CallbackData.CALENDAR_IGNORE))
             } else {
-                calendarDays.add(InlineKeyboardButton.CallbackData(day.toString(), "calendar_day_$date"))
+                calendarDays.add(InlineKeyboardButton.CallbackData(day.toString(), "${CallbackData.CALENDAR_DAY_PREFIX}$date"))
             }
         }
 

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/markup/Menus.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/markup/Menus.kt
@@ -2,18 +2,19 @@ package com.bookingbot.gateway.markup
 
 import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
 import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+import com.bookingbot.gateway.util.CallbackData
 
 object Menus {
 
-    val backToMainMenuButton = InlineKeyboardButton.CallbackData("⬅️ Главное меню", "back_to_main_menu")
+    val backToMainMenuButton = InlineKeyboardButton.CallbackData("⬅️ Главное меню", CallbackData.BACK_TO_MAIN_MENU)
 
     fun guestMenu(): InlineKeyboardMarkup {
         return InlineKeyboardMarkup.create(
             listOf(
-                listOf(InlineKeyboardButton.CallbackData(text = "Выбрать клуб", callbackData = "select_club")),
-                listOf(InlineKeyboardButton.CallbackData(text = "Мои бронирования", callbackData = "my_bookings")),
-                listOf(InlineKeyboardButton.CallbackData(text = "Задать вопрос", callbackData = "ask_question")),
-                listOf(InlineKeyboardButton.CallbackData(text = "Музыка", callbackData = "music_sets"))
+                listOf(InlineKeyboardButton.CallbackData(text = "Выбрать клуб", callbackData = CallbackData.SELECT_CLUB)),
+                listOf(InlineKeyboardButton.CallbackData(text = "Мои бронирования", callbackData = CallbackData.MY_BOOKINGS)),
+                listOf(InlineKeyboardButton.CallbackData(text = "Задать вопрос", callbackData = CallbackData.ASK_QUESTION)),
+                listOf(InlineKeyboardButton.CallbackData(text = "Музыка", callbackData = CallbackData.MUSIC_SETS))
             )
         )
     }
@@ -21,10 +22,10 @@ object Menus {
     fun clubMenu(clubId: Int): InlineKeyboardMarkup {
         return InlineKeyboardMarkup.create(
             listOf(
-                listOf(InlineKeyboardButton.CallbackData(text = "Забронировать стол", callbackData = "start_booking_$clubId")),
-                listOf(InlineKeyboardButton.CallbackData(text = "Информация", callbackData = "club_info_$clubId")),
-                listOf(InlineKeyboardButton.CallbackData(text = "Фотоотчеты", callbackData = "club_photos_$clubId")),
-                listOf(InlineKeyboardButton.CallbackData(text = "Афиши и события", callbackData = "club_events_$clubId")),
+                listOf(InlineKeyboardButton.CallbackData(text = "Забронировать стол", callbackData = "${CallbackData.START_BOOKING_PREFIX}$clubId")),
+                listOf(InlineKeyboardButton.CallbackData(text = "Информация", callbackData = "${CallbackData.CLUB_INFO_PREFIX}$clubId")),
+                listOf(InlineKeyboardButton.CallbackData(text = "Фотоотчеты", callbackData = "${CallbackData.CLUB_PHOTOS_PREFIX}$clubId")),
+                listOf(InlineKeyboardButton.CallbackData(text = "Афиши и события", callbackData = "${CallbackData.CLUB_EVENTS_PREFIX}$clubId")),
                 listOf(backToMainMenuButton)
             )
         )
@@ -38,9 +39,9 @@ object Menus {
     fun adminMenu(): InlineKeyboardMarkup {
         return InlineKeyboardMarkup.create(
             listOf(
-                listOf(InlineKeyboardButton.CallbackData(text = "Управление бронями", callbackData = "admin_manage_bookings")),
-                listOf(InlineKeyboardButton.CallbackData(text = "Управление столами", callbackData = "admin_manage_tables")),
-                listOf(InlineKeyboardButton.CallbackData(text = "Создать рассылку", callbackData = "admin_create_broadcast"))
+                listOf(InlineKeyboardButton.CallbackData(text = "Управление бронями", callbackData = CallbackData.ADMIN_MANAGE_BOOKINGS)),
+                listOf(InlineKeyboardButton.CallbackData(text = "Управление столами", callbackData = CallbackData.ADMIN_MANAGE_TABLES)),
+                listOf(InlineKeyboardButton.CallbackData(text = "Создать рассылку", callbackData = CallbackData.ADMIN_CREATE_BROADCAST))
             )
         )
     }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/util/CallbackData.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/util/CallbackData.kt
@@ -1,0 +1,43 @@
+package com.bookingbot.gateway.util
+
+object CallbackData {
+    const val BACK_TO_MAIN_MENU = "back_to_main_menu"
+    const val SELECT_CLUB = "select_club"
+    const val MY_BOOKINGS = "my_bookings"
+    const val ASK_QUESTION = "ask_question"
+    const val MUSIC_SETS = "music_sets"
+
+    const val ADMIN_MANAGE_BOOKINGS = "admin_manage_bookings"
+    const val ADMIN_MANAGE_TABLES = "admin_manage_tables"
+    const val ADMIN_CREATE_BROADCAST = "admin_create_broadcast"
+    const val PROMOTER_START_BOOKING = "promoter_start_booking"
+    const val PROMOTER_MY_BOOKINGS = "promoter_my_bookings"
+
+    const val BROADCAST_CONFIRM_SEND = "broadcast_confirm_send"
+    const val BROADCAST_CANCEL = "broadcast_cancel"
+
+    const val CONFIRM_BOOKING = "confirm_booking"
+    const val CANCEL_BOOKING_FSM = "cancel_booking_fsm"
+    const val EDIT_CAPACITY = "edit_capacity"
+    const val EDIT_DEPOSIT = "edit_deposit"
+
+    const val SHOW_CLUB_PREFIX = "show_club_"
+    const val START_BOOKING_PREFIX = "start_booking_"
+    const val CALENDAR_PREV_PREFIX = "calendar_prev_"
+    const val CALENDAR_NEXT_PREFIX = "calendar_next_"
+    const val CALENDAR_DAY_PREFIX = "calendar_day_"
+    const val CALENDAR_IGNORE = "calendar_ignore"
+    const val TABLE_PREFIX = "table_"
+    const val ADMIN_EDIT_TABLE_PREFIX = "admin_edit_table_"
+    const val ADMIN_CONFIRM_PREFIX = "admin_confirm_"
+    const val ADMIN_NOSHOW_PREFIX = "admin_noshow_"
+    const val ADMIN_CANCEL_PREFIX = "admin_cancel_"
+    const val CLUB_INFO_PREFIX = "club_info_"
+    const val CLUB_PHOTOS_PREFIX = "club_photos_"
+    const val CLUB_EVENTS_PREFIX = "club_events_"
+    const val ASK_CLUB_PREFIX = "ask_club_"
+    const val EDIT_BOOKING_PREFIX = "edit_booking_"
+    const val CANCEL_BOOKING_PREFIX = "cancel_booking_"
+    const val PLAY_SET_PREFIX = "play_set_"
+}
+


### PR DESCRIPTION
## Summary
- consolidate callback strings into `CallbackData`
- update markup and handlers to use the constants
- adjust calendar keyboard to use new constants

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68840a79ab7883219e85914214ab5c15