### PR TITLE
Add logback logging and Telegram API retry logic

### DIFF
--- a/bot-gateway/build.gradle.kts
+++ b/bot-gateway/build.gradle.kts
@@ -48,7 +48,8 @@ dependencies {
         exclude(group = "io.ktor")
     }
 
-    implementation("org.slf4j:slf4j-simple:2.0.7")
+    // centralized logging backend
+    implementation("ch.qos.logback:logback-classic:1.4.11")
 
     // В H2 нам нужен только для тестов в этом модуле
     testImplementation("com.h2database:h2:2.1.214")

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Bot.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Bot.kt
@@ -11,16 +11,22 @@ import com.github.kotlintelegrambot.dispatch
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
 import java.io.File
 
 fun startTelegramBot() {
     CoroutineScope(Dispatchers.IO).launch {
-        Bot.instance.startPolling()
-        println("Telegram Bot is listening for updates...")
+        try {
+            Bot.instance.startPolling()
+            logger.info("Telegram Bot is listening for updates...")
+        } catch (e: Exception) {
+            logger.error("Failed to start Telegram polling", e)
+        }
     }
 }
 
 object Bot {
+    private val logger = LoggerFactory.getLogger(Bot::class.java)
     // --- Пути к секретам в Docker ---
     private const val TOKEN_SECRET_PATH = "/run/secrets/telegram_bot_mix_token" // <<< ИЗМЕНЕНО
     private const val OWNERS_ID_SECRET_PATH = "/run/secrets/owner_id"

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/TelegramApi.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/TelegramApi.kt
@@ -1,0 +1,72 @@
+package com.bookingbot.gateway
+
+import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.ParseMode
+import com.github.kotlintelegrambot.entities.replymarkup.ReplyMarkup
+import com.github.kotlintelegrambot.network.Response
+import com.github.kotlintelegrambot.entities.Message
+import org.slf4j.LoggerFactory
+
+/**
+ * Wrapper around [Bot.instance] providing retry logic and centralized logging
+ * for Telegram API calls.
+ */
+object TelegramApi {
+    private val logger = LoggerFactory.getLogger(TelegramApi::class.java)
+    private const val MAX_RETRIES = 3
+    private const val RETRY_DELAY_MS = 1000L
+
+    fun sendMessage(
+        chatId: ChatId,
+        text: String,
+        parseMode: ParseMode? = null,
+        disableWebPagePreview: Boolean? = null,
+        replyMarkup: ReplyMarkup? = null
+    ): Response<Message> {
+        return withRetry {
+            Bot.instance.sendMessage(
+                chatId = chatId,
+                text = text,
+                parseMode = parseMode,
+                disableWebPagePreview = disableWebPagePreview,
+                replyMarkup = replyMarkup
+            )
+        }
+    }
+
+    fun forwardMessage(
+        chatId: ChatId,
+        fromChatId: ChatId,
+        messageId: Long
+    ): Response<Message> {
+        return withRetry {
+            Bot.instance.forwardMessage(
+                chatId = chatId,
+                fromChatId = fromChatId,
+                messageId = messageId
+            )
+        }
+    }
+
+    private fun <T> withRetry(block: () -> Response<T>): Response<T> {
+        var lastError: Exception? = null
+        repeat(MAX_RETRIES) { attempt ->
+            try {
+                val result = block()
+                if (result.isSuccess) {
+                    return result
+                }
+                logger.error(
+                    "Telegram API error: {}",
+                    result.getError()?.description
+                )
+            } catch (e: Exception) {
+                lastError = e
+                logger.warn("Telegram API call failed on attempt ${attempt + 1}", e)
+            }
+            Thread.sleep(RETRY_DELAY_MS)
+        }
+        logger.error("Telegram API call failed after $MAX_RETRIES attempts", lastError)
+        throw lastError ?: RuntimeException("Unknown Telegram API error")
+    }
+}

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminActionHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminActionHandler.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.services.BookingService
 import com.bookingbot.api.services.ClubService
@@ -73,7 +74,7 @@ fun addAdminActionHandler(dispatcher: Dispatcher, bookingService: BookingService
                         Для уточнения деталей, пожалуйста, свяжитесь с клубом.
                     """.trimIndent()
 
-                    bot.sendMessage(
+                    TelegramApi.sendMessage(
                         chatId = ChatId.fromId(bookingToCancel.userId),
                         text = guestNotificationText,
                         parseMode = ParseMode.MARKDOWN

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminDashboardHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminDashboardHandler.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.services.BookingService
 import com.bookingbot.api.services.UserService
@@ -29,11 +30,11 @@ fun addAdminDashboardHandler(dispatcher: Dispatcher, userService: UserService, b
         val bookings = bookingService.findActiveBookingsByClub(clubId)
 
         if (bookings.isEmpty()) {
-            bot.sendMessage(chatId, "В вашем клубе нет активных броней.")
+            TelegramApi.sendMessage(chatId, "В вашем клубе нет активных броней.")
             return@callbackQuery
         }
 
-        bot.sendMessage(chatId, "*Активные брони в вашем клубе:*", parseMode = ParseMode.MARKDOWN)
+        TelegramApi.sendMessage(chatId, "*Активные брони в вашем клубе:*", parseMode = ParseMode.MARKDOWN)
 
         val formatter = DateTimeFormatter.ofPattern("dd.MM HH:mm").withZone(ZoneId.systemDefault())
         bookings.forEach { booking ->
@@ -53,7 +54,7 @@ fun addAdminDashboardHandler(dispatcher: Dispatcher, userService: UserService, b
                 )
             )
 
-            bot.sendMessage(
+            TelegramApi.sendMessage(
                 chatId = chatId,
                 text = bookingInfo,
                 parseMode = ParseMode.MARKDOWN,

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminHandlers.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminHandlers.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.model.UserRole
 import com.bookingbot.api.services.ClubService
@@ -26,13 +27,13 @@ fun addAdminHandlers(dispatcher: Dispatcher, userService: UserService, clubServi
 
         // Проверяем, что команду использует админ или владелец
         if (admin.role != UserRole.ADMIN && admin.role != UserRole.OWNER) {
-            bot.sendMessage(ChatId.fromId(adminId), "У вас нет прав для использования этой команды.")
+            TelegramApi.sendMessage(ChatId.fromId(adminId), "У вас нет прав для использования этой команды.")
             return@command
         }
 
         val commandParts = message.text?.split(" ") ?: return@command
         if (commandParts.size < 3) {
-            bot.sendMessage(
+            TelegramApi.sendMessage(
                 ChatId.fromId(adminId),
                 "Неверный формат. Используйте: `/answer <ID пользователя> <текст ответа>`",
                 parseMode = ParseMode.MARKDOWN
@@ -42,22 +43,22 @@ fun addAdminHandlers(dispatcher: Dispatcher, userService: UserService, clubServi
 
         val targetUserId = commandParts[1].toLongOrNull()
         if (targetUserId == null) {
-            bot.sendMessage(ChatId.fromId(adminId), "Неверный ID пользователя.")
+            TelegramApi.sendMessage(ChatId.fromId(adminId), "Неверный ID пользователя.")
             return@command
         }
 
         val answerText = commandParts.drop(2).joinToString(" ")
 
-        val result = bot.sendMessage(
+        val result = TelegramApi.sendMessage(
             chatId = ChatId.fromId(targetUserId),
             text = "💬 *Ответ от администрации:*\n\n$answerText",
             parseMode = ParseMode.MARKDOWN
         )
 
         if (result.isSuccess) {
-            bot.sendMessage(ChatId.fromId(adminId), "✅ Ответ успешно отправлен пользователю $targetUserId.")
+            TelegramApi.sendMessage(ChatId.fromId(adminId), "✅ Ответ успешно отправлен пользователю $targetUserId.")
         } else {
-            bot.sendMessage(ChatId.fromId(adminId), "❌ Не удалось отправить ответ. Возможно, пользователь заблокировал бота.")
+            TelegramApi.sendMessage(ChatId.fromId(adminId), "❌ Не удалось отправить ответ. Возможно, пользователь заблокировал бота.")
         }
     }
 
@@ -66,13 +67,13 @@ fun addAdminHandlers(dispatcher: Dispatcher, userService: UserService, clubServi
         val requesterId = message.from?.id ?: return@command
 
         if (requesterId !in Bot.OWNER_IDS) {
-            bot.sendMessage(ChatId.fromId(requesterId), "Эта команда доступна только владельцам бота.")
+            TelegramApi.sendMessage(ChatId.fromId(requesterId), "Эта команда доступна только владельцам бота.")
             return@command
         }
 
         val commandParts = message.text?.split(" ") ?: return@command
         if (commandParts.size != 3) {
-            bot.sendMessage(
+            TelegramApi.sendMessage(
                 ChatId.fromId(requesterId),
                 "Неверный формат. Используйте: `/setrole <ID пользователя> <ROLE>`\nДоступные роли: GUEST, PROMOTER, ADMIN, OWNER",
                 parseMode = ParseMode.MARKDOWN
@@ -84,22 +85,22 @@ fun addAdminHandlers(dispatcher: Dispatcher, userService: UserService, clubServi
         val roleName = commandParts[2].uppercase()
 
         if (targetUserId == null) {
-            bot.sendMessage(ChatId.fromId(requesterId), "Неверный ID пользователя.")
+            TelegramApi.sendMessage(ChatId.fromId(requesterId), "Неверный ID пользователя.")
             return@command
         }
 
         val newRole = try {
             UserRole.valueOf(roleName)
         } catch (e: IllegalArgumentException) {
-            bot.sendMessage(ChatId.fromId(requesterId), "Неверная роль. Доступные: GUEST, PROMOTER, ADMIN, OWNER.")
+            TelegramApi.sendMessage(ChatId.fromId(requesterId), "Неверная роль. Доступные: GUEST, PROMOTER, ADMIN, OWNER.")
             return@command
         }
 
         if (userService.updateUserRole(targetUserId, newRole)) {
-            bot.sendMessage(ChatId.fromId(requesterId), "✅ Роль для пользователя $targetUserId успешно изменена на $newRole.")
-            bot.sendMessage(ChatId.fromId(targetUserId), "Вам была назначена новая роль: *$newRole*", parseMode = ParseMode.MARKDOWN)
+            TelegramApi.sendMessage(ChatId.fromId(requesterId), "✅ Роль для пользователя $targetUserId успешно изменена на $newRole.")
+            TelegramApi.sendMessage(ChatId.fromId(targetUserId), "Вам была назначена новая роль: *$newRole*", parseMode = ParseMode.MARKDOWN)
         } else {
-            bot.sendMessage(ChatId.fromId(requesterId), "❌ Не удалось найти пользователя с ID $targetUserId.")
+            TelegramApi.sendMessage(ChatId.fromId(requesterId), "❌ Не удалось найти пользователя с ID $targetUserId.")
         }
     }
 
@@ -108,13 +109,13 @@ fun addAdminHandlers(dispatcher: Dispatcher, userService: UserService, clubServi
         val requesterId = message.from?.id ?: return@command
 
         if (requesterId !in Bot.OWNER_IDS) {
-            bot.sendMessage(ChatId.fromId(requesterId), "Эта команда доступна только владельцам бота.")
+            TelegramApi.sendMessage(ChatId.fromId(requesterId), "Эта команда доступна только владельцам бота.")
             return@command
         }
 
         val commandParts = message.text?.split(" ") ?: return@command
         if (commandParts.size != 4) {
-            bot.sendMessage(
+            TelegramApi.sendMessage(
                 ChatId.fromId(requesterId),
                 "Неверный формат. Используйте: `/addstaff <ID пользователя> <ID клуба> <ROLE>`\nРоли: ADMIN, PROMOTER",
                 parseMode = ParseMode.MARKDOWN
@@ -127,29 +128,29 @@ fun addAdminHandlers(dispatcher: Dispatcher, userService: UserService, clubServi
         val roleName = commandParts[3].uppercase()
 
         if (targetUserId == null || targetClubId == null) {
-            bot.sendMessage(ChatId.fromId(requesterId), "Неверный формат ID пользователя или клуба.")
+            TelegramApi.sendMessage(ChatId.fromId(requesterId), "Неверный формат ID пользователя или клуба.")
             return@command
         }
 
         val role = try { UserRole.valueOf(roleName) } catch (e: Exception) { null }
 
         if (role != UserRole.ADMIN && role != UserRole.PROMOTER) {
-            bot.sendMessage(ChatId.fromId(requesterId), "Неверная роль. Доступные: ADMIN, PROMOTER.")
+            TelegramApi.sendMessage(ChatId.fromId(requesterId), "Неверная роль. Доступные: ADMIN, PROMOTER.")
             return@command
         }
 
         if (clubService.findClubById(targetClubId) == null) {
-            bot.sendMessage(ChatId.fromId(requesterId), "Клуб с ID $targetClubId не найден.")
+            TelegramApi.sendMessage(ChatId.fromId(requesterId), "Клуб с ID $targetClubId не найден.")
             return@command
         }
 
         userService.findOrCreateUser(targetUserId, null)
 
         if (userService.assignUserToClub(targetUserId, targetClubId, role)) {
-            bot.sendMessage(ChatId.fromId(requesterId), "✅ Пользователь $targetUserId успешно назначен на роль $role в клубе $targetClubId.")
-            bot.sendMessage(ChatId.fromId(targetUserId), "Вам назначена роль *$role* для клуба (ID: $targetClubId).", parseMode = ParseMode.MARKDOWN)
+            TelegramApi.sendMessage(ChatId.fromId(requesterId), "✅ Пользователь $targetUserId успешно назначен на роль $role в клубе $targetClubId.")
+            TelegramApi.sendMessage(ChatId.fromId(targetUserId), "Вам назначена роль *$role* для клуба (ID: $targetClubId).", parseMode = ParseMode.MARKDOWN)
         } else {
-            bot.sendMessage(ChatId.fromId(requesterId), "❌ Не удалось назначить пользователя.")
+            TelegramApi.sendMessage(ChatId.fromId(requesterId), "❌ Не удалось назначить пользователя.")
         }
     }
 
@@ -159,12 +160,12 @@ fun addAdminHandlers(dispatcher: Dispatcher, userService: UserService, clubServi
         val admin = userService.findOrCreateUser(adminId, null)
 
         if (admin.role != UserRole.ADMIN && admin.role != UserRole.OWNER) {
-            bot.sendMessage(ChatId.fromId(adminId), "У вас нет прав для использования этой команды.")
+            TelegramApi.sendMessage(ChatId.fromId(adminId), "У вас нет прав для использования этой команды.")
             return@command
         }
 
         StateStorage.setState(adminId, State.AdminBookingGuestName)
-        bot.sendMessage(ChatId.fromId(adminId), "Начинаем создание брони. Введите имя гостя:")
+        TelegramApi.sendMessage(ChatId.fromId(adminId), "Начинаем создание брони. Введите имя гостя:")
     }
 
     // Админ вводит имя гостя
@@ -174,7 +175,7 @@ fun addAdminHandlers(dispatcher: Dispatcher, userService: UserService, clubServi
 
         StateStorage.getContext(adminId).bookingGuestName = guestName
         StateStorage.setState(adminId, State.AdminBookingSource)
-        bot.sendMessage(ChatId.fromId(adminId), "Имя гостя '$guestName' принято. Теперь введите источник брони (например, 'Звонок', 'Instagram'):")
+        TelegramApi.sendMessage(ChatId.fromId(adminId), "Имя гостя '$guestName' принято. Теперь введите источник брони (например, 'Звонок', 'Instagram'):")
     }
 
     // Админ вводит источник брони
@@ -184,7 +185,7 @@ fun addAdminHandlers(dispatcher: Dispatcher, userService: UserService, clubServi
 
         StateStorage.getContext(adminId).source = source
         StateStorage.setState(adminId, State.AdminBookingPhone)
-        bot.sendMessage(ChatId.fromId(adminId), "Источник '$source' принят. Теперь введите номер телефона гостя:")
+        TelegramApi.sendMessage(ChatId.fromId(adminId), "Источник '$source' принят. Теперь введите номер телефона гостя:")
     }
 
     // Админ вводит номер телефона гостя и переходит к выбору клуба
@@ -194,7 +195,7 @@ fun addAdminHandlers(dispatcher: Dispatcher, userService: UserService, clubServi
 
         val phoneRegex = """^\+?\d{10,14}$""".toRegex()
         if (phone == null || !phone.matches(phoneRegex)) {
-            bot.sendMessage(ChatId.fromId(adminId), "Неверный формат номера. Пожалуйста, введите номер в международном формате, например: +79991234567")
+            TelegramApi.sendMessage(ChatId.fromId(adminId), "Неверный формат номера. Пожалуйста, введите номер в международном формате, например: +79991234567")
             return@message
         }
 
@@ -206,7 +207,7 @@ fun addAdminHandlers(dispatcher: Dispatcher, userService: UserService, clubServi
             InlineKeyboardButton.CallbackData(it.name, "${CallbackData.SHOW_CLUB_PREFIX}${it.id}")
         }.chunked(2)
 
-        bot.sendMessage(
+        TelegramApi.sendMessage(
             chatId = ChatId.fromId(adminId),
             text = "Телефон '$phone' принят. Теперь выберите клуб для бронирования:",
             replyMarkup = InlineKeyboardMarkup.create(clubButtons)

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminTableManagementHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/adminTableManagementHandler.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.services.TableService
 import com.bookingbot.api.services.UserService
@@ -29,7 +30,7 @@ fun addAdminTableManagementHandler(dispatcher: Dispatcher, tableService: TableSe
 
         val tables = tableService.getTablesForClub(clubId)
         if (tables.isEmpty()) {
-            bot.sendMessage(ChatId.fromId(adminId), "В вашем клубе еще не добавлены столы.")
+            TelegramApi.sendMessage(ChatId.fromId(adminId), "В вашем клубе еще не добавлены столы.")
             return@callbackQuery
         }
 
@@ -38,7 +39,7 @@ fun addAdminTableManagementHandler(dispatcher: Dispatcher, tableService: TableSe
         }.chunked(1)
 
         StateStorage.setState(adminId, State.AdminSelectTableToEdit)
-        bot.sendMessage(ChatId.fromId(adminId), "Выберите стол для редактирования:", replyMarkup = InlineKeyboardMarkup.create(tableButtons))
+        TelegramApi.sendMessage(ChatId.fromId(adminId), "Выберите стол для редактирования:", replyMarkup = InlineKeyboardMarkup.create(tableButtons))
     }
 
     // Шаг 2: Админ выбрал стол, спрашиваем, что редактировать
@@ -63,11 +64,11 @@ fun addAdminTableManagementHandler(dispatcher: Dispatcher, tableService: TableSe
         when(callbackQuery.data) {
             CallbackData.EDIT_CAPACITY -> {
                 StateStorage.setState(adminId, State.AdminEditingTableCapacity)
-                bot.sendMessage(ChatId.fromId(adminId), "Введите новую вместимость (число):")
+                TelegramApi.sendMessage(ChatId.fromId(adminId), "Введите новую вместимость (число):")
             }
             CallbackData.EDIT_DEPOSIT -> {
                 StateStorage.setState(adminId, State.AdminEditingTableDeposit)
-                bot.sendMessage(ChatId.fromId(adminId), "Введите новый депозит (число):")
+                TelegramApi.sendMessage(ChatId.fromId(adminId), "Введите новый депозит (число):")
             }
         }
     }
@@ -80,9 +81,9 @@ fun addAdminTableManagementHandler(dispatcher: Dispatcher, tableService: TableSe
 
         if (newCapacity != null && tableId != null) {
             tableService.updateTableCapacity(tableId, newCapacity)
-            bot.sendMessage(ChatId.fromId(adminId), "Вместимость стола №$tableId обновлена на $newCapacity.")
+            TelegramApi.sendMessage(ChatId.fromId(adminId), "Вместимость стола №$tableId обновлена на $newCapacity.")
         } else {
-            bot.sendMessage(ChatId.fromId(adminId), "Ошибка. Введите корректное число.")
+            TelegramApi.sendMessage(ChatId.fromId(adminId), "Ошибка. Введите корректное число.")
         }
         StateStorage.clear(adminId)
     }
@@ -95,9 +96,9 @@ fun addAdminTableManagementHandler(dispatcher: Dispatcher, tableService: TableSe
 
         if (newDeposit != null && tableId != null) {
             tableService.updateTableDeposit(tableId, newDeposit)
-            bot.sendMessage(ChatId.fromId(adminId), "Депозит стола №$tableId обновлен на $newDeposit.")
+            TelegramApi.sendMessage(ChatId.fromId(adminId), "Депозит стола №$tableId обновлен на $newDeposit.")
         } else {
-            bot.sendMessage(ChatId.fromId(adminId), "Ошибка. Введите корректное число.")
+            TelegramApi.sendMessage(ChatId.fromId(adminId), "Ошибка. Введите корректное число.")
         }
         StateStorage.clear(adminId)
     }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/askQuestionHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/askQuestionHandler.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.services.ClubService
 import com.bookingbot.gateway.fsm.State
@@ -26,7 +27,7 @@ fun addAskQuestionHandler(dispatcher: Dispatcher, clubService: ClubService) {
             InlineKeyboardButton.CallbackData(text = club.name, callbackData = "${CallbackData.ASK_CLUB_PREFIX}${club.id}")
         }.chunked(2)
 
-        bot.sendMessage(
+        TelegramApi.sendMessage(
             chatId = chatId,
             text = "Выберите клуб, которому хотите задать вопрос:",
             replyMarkup = InlineKeyboardMarkup.create(clubButtons)
@@ -70,13 +71,13 @@ fun addAskQuestionHandler(dispatcher: Dispatcher, clubService: ClubService) {
                 _Чтобы ответить, используйте команду `/answer ${message.from?.id} <текст ответа>`_
             """.trimIndent()
 
-            bot.sendMessage(
+            TelegramApi.sendMessage(
                 chatId = ChatId.fromId(channelId),
                 text = notification,
                 parseMode = ParseMode.MARKDOWN
             )
-            bot.sendMessage(chatId, "Ваш вопрос отправлен администрации клуба '${club.name}'. Ожидайте ответа.")
-        } ?: bot.sendMessage(chatId, "Не удалось отправить ваш вопрос. Попробуйте позже.")
+            TelegramApi.sendMessage(chatId, "Ваш вопрос отправлен администрации клуба '${club.name}'. Ожидайте ответа.")
+        } ?: TelegramApi.sendMessage(chatId, "Не удалось отправить ваш вопрос. Попробуйте позже.")
 
         StateStorage.clear(chatId.id)
     }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/broadcastHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/broadcastHandler.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.model.UserRole
 import com.bookingbot.api.services.UserService
@@ -30,7 +31,7 @@ fun addBroadcastHandler(dispatcher: Dispatcher, userService: UserService) {
         }
 
         StateStorage.setState(adminId, State.BroadcastMessageInput)
-        bot.sendMessage(ChatId.fromId(adminId), "Введите сообщение для рассылки. Вы можете использовать форматирование и прикрепить фото.")
+        TelegramApi.sendMessage(ChatId.fromId(adminId), "Введите сообщение для рассылки. Вы можете использовать форматирование и прикрепить фото.")
     }
 
     // Шаг 2: Админ отправляет сообщение для рассылки (любого типа)
@@ -47,7 +48,7 @@ fun addBroadcastHandler(dispatcher: Dispatcher, userService: UserService) {
         ))
 
         StateStorage.setState(adminId, State.BroadcastConfirmation)
-        bot.sendMessage(ChatId.fromId(adminId), "Вы уверены, что хотите отправить это сообщение всем пользователям?", replyMarkup = confirmationKeyboard)
+        TelegramApi.sendMessage(ChatId.fromId(adminId), "Вы уверены, что хотите отправить это сообщение всем пользователям?", replyMarkup = confirmationKeyboard)
     }
 
     // Шаг 3: Админ подтверждает или отменяет рассылку
@@ -61,7 +62,7 @@ fun addBroadcastHandler(dispatcher: Dispatcher, userService: UserService) {
         when (callbackQuery.data) {
             CallbackData.BROADCAST_CONFIRM_SEND -> {
                 if (messageIdToForward == null) {
-                    bot.sendMessage(ChatId.fromId(adminId), "Ошибка: не найдено сообщение для рассылки.")
+                    TelegramApi.sendMessage(ChatId.fromId(adminId), "Ошибка: не найдено сообщение для рассылки.")
                     StateStorage.clear(adminId)
                     return@callbackQuery
                 }
@@ -77,7 +78,7 @@ fun addBroadcastHandler(dispatcher: Dispatcher, userService: UserService) {
                     userIds.forEach { userId ->
                         try {
                             // Используем forwardMessage, чтобы сохранить форматирование, фото и т.д.
-                            bot.forwardMessage(
+                            TelegramApi.forwardMessage(
                                 chatId = ChatId.fromId(userId),
                                 fromChatId = ChatId.fromId(adminId),
                                 messageId = messageIdToForward
@@ -89,7 +90,7 @@ fun addBroadcastHandler(dispatcher: Dispatcher, userService: UserService) {
                             failCount++
                         }
                     }
-                    bot.sendMessage(ChatId.fromId(adminId), "✅ Рассылка завершена.\nУспешно: $successCount\nНе удалось: $failCount")
+                    TelegramApi.sendMessage(ChatId.fromId(adminId), "✅ Рассылка завершена.\nУспешно: $successCount\nНе удалось: $failCount")
                 }
             }
             CallbackData.BROADCAST_CANCEL -> {

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/clubInfoHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/clubInfoHandler.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.services.ClubService
 import com.bookingbot.api.services.EventService
@@ -53,9 +54,9 @@ fun addClubInfoHandler(dispatcher: Dispatcher, clubService: ClubService, tableSe
                         *Телефон:* +7 (999) 123-45-67
                     """.trimIndent()
 
-                    bot.sendMessage(chatId, text = infoText, parseMode = ParseMode.MARKDOWN)
+                    TelegramApi.sendMessage(chatId, text = infoText, parseMode = ParseMode.MARKDOWN)
                 } else {
-                    bot.sendMessage(chatId, text = "Информация о клубе не найдена.")
+                    TelegramApi.sendMessage(chatId, text = "Информация о клубе не найдена.")
                 }
             }
             data.startsWith(CallbackData.CLUB_PHOTOS_PREFIX) -> {
@@ -66,7 +67,7 @@ fun addClubInfoHandler(dispatcher: Dispatcher, clubService: ClubService, tableSe
                 val events = eventService.findUpcomingEventsByClub(clubId)
 
                 if (events.isEmpty()) {
-                    bot.sendMessage(chatId, "В ближайшее время мероприятий не запланировано.")
+                    TelegramApi.sendMessage(chatId, "В ближайшее время мероприятий не запланировано.")
                     return@callbackQuery
                 }
 
@@ -74,7 +75,7 @@ fun addClubInfoHandler(dispatcher: Dispatcher, clubService: ClubService, tableSe
                 val eventsText = events.joinToString("\n\n") {
                     "*${formatter.format(it.eventDate)}* - ${it.title}"
                 }
-                bot.sendMessage(chatId, "*Ближайшие события:*\n\n$eventsText", parseMode = ParseMode.MARKDOWN)
+                TelegramApi.sendMessage(chatId, "*Ближайшие события:*\n\n$eventsText", parseMode = ParseMode.MARKDOWN)
             }
         }
     }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/contentHandlers.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/contentHandlers.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.github.kotlintelegrambot.dispatcher.Dispatcher
 import com.github.kotlintelegrambot.dispatcher.callbackQuery
@@ -25,7 +26,7 @@ fun addContentHandlers(dispatcher: Dispatcher) {
             listOf(InlineKeyboardButton.CallbackData(text = title, callbackData = callbackData))
         }
 
-        bot.sendMessage(
+        TelegramApi.sendMessage(
             chatId = chatId,
             text = "🎧 Последние музыкальные сеты от наших резидентов:",
             replyMarkup = InlineKeyboardMarkup.create(musicButtons)
@@ -53,7 +54,7 @@ fun addContentHandlers(dispatcher: Dispatcher) {
             "Не удалось найти этот сет."
         }
 
-        bot.sendMessage(
+        TelegramApi.sendMessage(
             chatId = chatId,
             text = text,
             parseMode = ParseMode.MARKDOWN,

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/myBookingsHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/myBookingsHandler.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.services.BookingService
 import com.bookingbot.api.services.ClubService
@@ -20,7 +21,7 @@ fun addMyBookingsHandler(dispatcher: Dispatcher, bookingService: BookingService,
         val bookings = bookingService.findBookingsByUserId(chatId.id)
 
         if (bookings.isEmpty()) {
-            bot.sendMessage(chatId, "У вас пока нет активных бронирований.")
+            TelegramApi.sendMessage(chatId, "У вас пока нет активных бронирований.")
             return@callbackQuery
         }
 
@@ -50,7 +51,7 @@ fun addMyBookingsHandler(dispatcher: Dispatcher, bookingService: BookingService,
                 null
             }
 
-            bot.sendMessage(
+            TelegramApi.sendMessage(
                 chatId = chatId,
                 text = bookingInfo,
                 replyMarkup = bookingMenu,

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/navigationHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/navigationHandler.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.model.UserRole
 import com.bookingbot.api.services.UserService
@@ -16,7 +17,7 @@ fun addNavigationHandler(dispatcher: Dispatcher, userService: UserService) {
     dispatcher.command("cancel") {
         val userId = message.from?.id ?: return@command
         StateStorage.clear(userId)
-        bot.sendMessage(ChatId.fromId(userId), "Действие отменено. Вы в главном меню.")
+        TelegramApi.sendMessage(ChatId.fromId(userId), "Действие отменено. Вы в главном меню.")
         // Повторно вызываем /start, чтобы показать актуальное меню
         dispatcher.command("start")?.handler?.handleUpdate(bot, update)
     }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/ownerHandlers.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/ownerHandlers.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.services.ClubService
 import com.bookingbot.api.services.TableService
@@ -20,12 +21,12 @@ fun addOwnerHandlers(dispatcher: Dispatcher, clubService: ClubService, tableServ
 
         val clubName = args.joinToString(" ")
         if (clubName.isBlank()) {
-            bot.sendMessage(ChatId.fromId(message.chat.id), "Укажите название клуба: `/addclub <название>`", parseMode = ParseMode.MARKDOWN)
+            TelegramApi.sendMessage(ChatId.fromId(message.chat.id), "Укажите название клуба: `/addclub <название>`", parseMode = ParseMode.MARKDOWN)
             return@command
         }
 
         val newClub = clubService.createClub(clubName, "Описание для ${clubName}")
-        bot.sendMessage(ChatId.fromId(message.chat.id), "✅ Клуб '${newClub.name}' успешно создан с ID: ${newClub.id}")
+        TelegramApi.sendMessage(ChatId.fromId(message.chat.id), "✅ Клуб '${newClub.name}' успешно создан с ID: ${newClub.id}")
     }
 
     // Команда для установки канала администраторов
@@ -33,21 +34,21 @@ fun addOwnerHandlers(dispatcher: Dispatcher, clubService: ClubService, tableServ
         if (message.from?.id !in OWNER_IDS) return@command
 
         if (args.size != 2) {
-            bot.sendMessage(ChatId.fromId(message.chat.id), "Формат: `/setclubchannel <ID клуба> <ID канала>`", parseMode = ParseMode.MARKDOWN)
+            TelegramApi.sendMessage(ChatId.fromId(message.chat.id), "Формат: `/setclubchannel <ID клуба> <ID канала>`", parseMode = ParseMode.MARKDOWN)
             return@command
         }
         val clubId = args[0].toIntOrNull()
         val channelId = args[1].toLongOrNull()
 
         if (clubId == null || channelId == null) {
-            bot.sendMessage(ChatId.fromId(message.chat.id), "Неверный формат ID.")
+            TelegramApi.sendMessage(ChatId.fromId(message.chat.id), "Неверный формат ID.")
             return@command
         }
 
         if (clubService.setAdminChannel(clubId, channelId)) {
-            bot.sendMessage(ChatId.fromId(message.chat.id), "✅ Канал $channelId успешно назначен для клуба $clubId.")
+            TelegramApi.sendMessage(ChatId.fromId(message.chat.id), "✅ Канал $channelId успешно назначен для клуба $clubId.")
         } else {
-            bot.sendMessage(ChatId.fromId(message.chat.id), "❌ Не удалось найти клуб с ID $clubId.")
+            TelegramApi.sendMessage(ChatId.fromId(message.chat.id), "❌ Не удалось найти клуб с ID $clubId.")
         }
     }
 
@@ -56,7 +57,7 @@ fun addOwnerHandlers(dispatcher: Dispatcher, clubService: ClubService, tableServ
         if (message.from?.id !in OWNER_IDS) return@command
 
         if (args.size != 4) {
-            bot.sendMessage(ChatId.fromId(message.chat.id), "Формат: `/addtable <ID клуба> <номер стола> <вместимость> <депозит>`", parseMode = ParseMode.MARKDOWN)
+            TelegramApi.sendMessage(ChatId.fromId(message.chat.id), "Формат: `/addtable <ID клуба> <номер стола> <вместимость> <депозит>`", parseMode = ParseMode.MARKDOWN)
             return@command
         }
         val clubId = args[0].toIntOrNull()
@@ -65,12 +66,12 @@ fun addOwnerHandlers(dispatcher: Dispatcher, clubService: ClubService, tableServ
         val deposit = args[3].toBigDecimalOrNull()
 
         if (clubId == null || tableNumber == null || capacity == null || deposit == null) {
-            bot.sendMessage(ChatId.fromId(message.chat.id), "Неверный формат данных.")
+            TelegramApi.sendMessage(ChatId.fromId(message.chat.id), "Неверный формат данных.")
             return@command
         }
 
         val newTable = tableService.createTable(clubId, tableNumber, capacity, deposit)
-        bot.sendMessage(ChatId.fromId(message.chat.id), "✅ Стол №${newTable.number} добавлен в клуб $clubId.")
+        TelegramApi.sendMessage(ChatId.fromId(message.chat.id), "✅ Стол №${newTable.number} добавлен в клуб $clubId.")
     }
 
     // Команда для добавления нового события/афиши
@@ -79,7 +80,7 @@ fun addOwnerHandlers(dispatcher: Dispatcher, clubService: ClubService, tableServ
 
         // Формат: /addevent <ID клуба> <ДД.ММ.ГГГГ> <Заголовок>
         if (args.size < 3) {
-            bot.sendMessage(ChatId.fromId(message.chat.id), "Формат: `/addevent <ID клуба> <ДД.ММ.ГГГГ> <Заголовок>`", parseMode = ParseMode.MARKDOWN)
+            TelegramApi.sendMessage(ChatId.fromId(message.chat.id), "Формат: `/addevent <ID клуба> <ДД.ММ.ГГГГ> <Заголовок>`", parseMode = ParseMode.MARKDOWN)
             return@command
         }
         val clubId = args[0].toIntOrNull()
@@ -87,13 +88,13 @@ fun addOwnerHandlers(dispatcher: Dispatcher, clubService: ClubService, tableServ
         val title = args.drop(2).joinToString(" ")
 
         if (clubId == null || date == null || title.isBlank()) {
-            bot.sendMessage(ChatId.fromId(message.chat.id), "Неверный формат данных.")
+            TelegramApi.sendMessage(ChatId.fromId(message.chat.id), "Неверный формат данных.")
             return@command
         }
 
         // Опционально: можно добавить запрос на описание и картинку в FSM
         eventService.createEvent(clubId, title, "Описание скоро будет...", date.atStartOfDay(ZoneId.systemDefault()).toInstant(), null)
-        bot.sendMessage(ChatId.fromId(message.chat.id), "✅ Новое событие '$title' добавлено для клуба $clubId.")
+        TelegramApi.sendMessage(ChatId.fromId(message.chat.id), "✅ Новое событие '$title' добавлено для клуба $clubId.")
     }
 }
 

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/promoterDashboardHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/promoterDashboardHandler.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.services.BookingService
 import com.bookingbot.api.services.ClubService
@@ -21,11 +22,11 @@ fun addPromoterDashboardHandler(dispatcher: Dispatcher, bookingService: BookingS
         val bookings = bookingService.findBookingsByPromoterId(promoterId)
 
         if (bookings.isEmpty()) {
-            bot.sendMessage(chatId, "Вы еще не создали ни одного бронирования для гостей.")
+            TelegramApi.sendMessage(chatId, "Вы еще не создали ни одного бронирования для гостей.")
             return@callbackQuery
         }
 
-        bot.sendMessage(chatId, "*Ваши бронирования для гостей:*", parseMode = ParseMode.MARKDOWN)
+        TelegramApi.sendMessage(chatId, "*Ваши бронирования для гостей:*", parseMode = ParseMode.MARKDOWN)
 
         val formatter = DateTimeFormatter.ofPattern("dd.MM HH:mm").withZone(ZoneId.systemDefault())
         bookings.forEach { booking ->
@@ -40,7 +41,7 @@ fun addPromoterDashboardHandler(dispatcher: Dispatcher, bookingService: BookingS
                 *Статус:* `${booking.status}`
             """.trimIndent()
 
-            bot.sendMessage(
+            TelegramApi.sendMessage(
                 chatId = chatId,
                 text = bookingInfo,
                 parseMode = ParseMode.MARKDOWN_V2

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/promoterHandlers.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/promoterHandlers.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.model.UserRole
 import com.bookingbot.api.services.ClubService
@@ -30,7 +31,7 @@ fun addPromoterHandlers(dispatcher: Dispatcher, userService: UserService, clubSe
 
         // Устанавливаем состояние ожидания имени гостя
         StateStorage.setState(promoterId, State.PromoterGuestNameInput)
-        bot.sendMessage(
+        TelegramApi.sendMessage(
             chatId = ChatId.fromId(promoterId),
             text = "Вы начали создание брони для гостя. Пожалуйста, введите имя гостя:"
         )
@@ -54,7 +55,7 @@ fun addPromoterHandlers(dispatcher: Dispatcher, userService: UserService, clubSe
             InlineKeyboardButton.CallbackData(it.name, "${CallbackData.SHOW_CLUB_PREFIX}${it.id}")
         }.chunked(2)
 
-        bot.sendMessage(
+        TelegramApi.sendMessage(
             chatId = ChatId.fromId(promoterId),
             text = "Имя гостя '$guestName' принято. Теперь выберите клуб:",
             replyMarkup = InlineKeyboardMarkup.create(clubButtons)

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/startHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/startHandler.kt
@@ -1,4 +1,5 @@
 package com.bookingbot.gateway.handlers
+import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.model.UserRole
 import com.bookingbot.api.services.UserService
@@ -18,7 +19,7 @@ fun addStartHandler(dispatcher: Dispatcher, userService: UserService) {
             UserRole.OWNER -> "Панель владельца. Выберите действие:" to Menus.adminMenu() // Владелец пока использует меню админа
         }
 
-        bot.sendMessage(
+        TelegramApi.sendMessage(
             chatId = ChatId.fromId(message.chat.id),
             text = "Здравствуйте, ${user.username ?: "Гость"}! 👋\nВаша роль: ${user.role}.\n\n$menuText",
             replyMarkup = menuMarkup

--- a/bot-gateway/src/main/resources/logback.xml
+++ b/bot-gateway/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- introduce Logback as logging backend
- configure logger in `Bot` and replace `println`
- add `TelegramApi` wrapper with retry logic for Telegram calls
- route all handlers through new wrapper
- supply Logback config

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_6884101077c8832194ef95c8c7503675