### PR TITLE
Display hall scheme image

### DIFF
--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/HallSchemeSender.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/HallSchemeSender.kt
@@ -13,6 +13,14 @@ import java.io.File
 import java.nio.file.Files
 import javax.imageio.ImageIO
 
+/** Coordinates of tables on the hall scheme image. */
+private val TABLE_COORDINATES: Map<Int, Point> = mapOf(
+    1 to Point(80, 80),
+    2 to Point(160, 80),
+    3 to Point(80, 160),
+    4 to Point(160, 160)
+)
+
 /**
  * Sends a hall scheme image with highlighted free tables.
  *
@@ -25,12 +33,7 @@ fun Bot.sendHallScheme(
     freeTables: List<Int>,
     hallSchemePath: String = "resources/hall.png"
 ) {
-    val tablePoints: Map<Int, Point> = mapOf(
-        1 to Point(80, 80),
-        2 to Point(160, 80),
-        3 to Point(80, 160),
-        4 to Point(160, 160)
-    )
+    // TODO: adjust TABLE_COORDINATES to match actual hall scheme layout
 
     val base = ImageIO.read(File(hallSchemePath))
     val image = BufferedImage(base.width, base.height, BufferedImage.TYPE_INT_ARGB)
@@ -40,7 +43,7 @@ fun Bot.sendHallScheme(
         g.font = Font("Inter", Font.BOLD, 20)
         g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
         for (id in freeTables) {
-            val p = tablePoints[id] ?: continue
+            val p = TABLE_COORDINATES[id] ?: continue
             g.color = Color(0, 200, 0)
             g.fillOval(p.x - 20, p.y - 20, 40, 40)
             g.color = Color.WHITE


### PR DESCRIPTION
## Summary
- highlight free tables on the hall scheme
- expose `/tables` command
- extract table coordinate map

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6884383516848321a90efa2cf3cf1eb3