### PR TITLE
Fix SQL injection in DatabaseFactory

### DIFF
--- a/booking-api/src/test/kotlin/com/bookingbot/api/DatabaseFactoryTest.kt
+++ b/booking-api/src/test/kotlin/com/bookingbot/api/DatabaseFactoryTest.kt
@@ -1,16 +1,16 @@
 package com.bookingbot.api
 
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.assertThrows
 
 class DatabaseFactoryTest {
 
     @Test
-    fun `database factory correctly reports table existence`() {
+    fun `exists validates table name`() {
         DatabaseFactory.init() // Инициализирует БД и создаёт таблицу Bookings для H2
 
         assertTrue(DatabaseFactory.exists("bookings"), "Таблица 'bookings' должна существовать после init()")
-        assertFalse(DatabaseFactory.exists("non_existent_table"), "Таблица 'non_existent_table' не должна существовать")
+        assertThrows<IllegalArgumentException> { DatabaseFactory.exists("non_existent_table") }
     }
 }


### PR DESCRIPTION
## Summary
- secure the `exists` method by validating table name
- update test to expect exception on invalid table name

## Testing
- `./gradlew test --no-daemon` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68850cb6f60483218eb2df145d3650a1