### PR TITLE
Fix waitlist loop and add scheduler

### DIFF
--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Application.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Application.kt
@@ -3,6 +3,9 @@ package com.bookingbot.gateway
 import io.ktor.server.application.Application
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
+import com.bookingbot.gateway.waitlist.WaitlistScheduler
+import java.time.Duration
+import org.koin.ktor.ext.get
 
 fun main() {
     embeddedServer(
@@ -15,6 +18,8 @@ fun main() {
 
 fun Application.module() {
     configureDI()
+    val scheduler = WaitlistScheduler(get(), Duration.ofMinutes(1))
+    scheduler.start()
     configureAuth()
     configureRouting()
 }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/waitlist/Waitlist.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/waitlist/Waitlist.kt
@@ -16,7 +16,6 @@ import com.bookingbot.gateway.util.CallbackData
 import com.github.kotlintelegrambot.dispatcher.Dispatcher
 import com.github.kotlintelegrambot.dispatcher.command
 import com.github.kotlintelegrambot.entities.ChatId
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -34,19 +33,8 @@ class WaitlistNotifierImpl(
 ) : WaitlistNotifier {
     private val logger = LoggerFactory.getLogger(WaitlistNotifierImpl::class.java)
 
-    init { start() }
-
     override fun onNewBooking() { ApplicationScope.launch { scanWaitlist() } }
     override fun onCancel() { ApplicationScope.launch { scanWaitlist() } }
-
-    private fun start() {
-        ApplicationScope.launch {
-            while (true) {
-                scanWaitlist()
-                delay(15 * 60_000L)
-            }
-        }
-    }
 
     fun scanWaitlist() {
         val entries = WaitlistDao.findActive()

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/waitlist/WaitlistScheduler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/waitlist/WaitlistScheduler.kt
@@ -1,0 +1,30 @@
+package com.bookingbot.gateway.waitlist
+
+import com.bookingbot.api.services.BookingService
+import io.ktor.server.application.*
+import kotlinx.coroutines.*
+import java.time.Duration
+
+/**
+ * Periodically processes wait-list entries.
+ *
+ * Starts a repeating coroutine on application start and
+ * cancels it on ApplicationStopped to avoid leaks.
+ */
+class WaitlistScheduler(
+    private val bookingService: BookingService,
+    private val period: Duration = Duration.ofMinutes(1)
+) {
+    private lateinit var job: Job
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    fun Application.start() {
+        job = scope.launch {
+            while (isActive) {
+                bookingService.processWaitlist()   // existing business logic
+                delay(period.toMillis())
+            }
+        }
+        environment.monitor.subscribe(ApplicationStopped) { job.cancel() }
+    }
+}


### PR DESCRIPTION
## Summary
- replace infinite coroutine loop with `WaitlistScheduler`
- remove `delay` usage and start logic from `WaitlistNotifierImpl`
- start the periodic scheduler during application startup

## Testing
- `./gradlew build -x test` *(fails: Could not resolve dependencies from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68850df7dcd08321833e70db20d65f20