### PR TITLE
Refactor StateStorage to suspend API

### DIFF
--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/navigationHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/navigationHandler.kt
@@ -3,7 +3,7 @@ import com.bookingbot.gateway.TelegramApi
 
 import com.bookingbot.api.model.UserRole
 import com.bookingbot.api.services.UserService
-import com.bookingbot.gateway.fsm.StateStorage
+import com.bookingbot.gateway.fsm.StateStorageImpl
 import com.bookingbot.gateway.markup.Menus
 import com.bookingbot.gateway.util.CallbackData
 import com.github.kotlintelegrambot.dispatcher.Dispatcher
@@ -16,7 +16,7 @@ fun addNavigationHandler(dispatcher: Dispatcher, userService: UserService) {
     // Обработчик для команды /cancel
     dispatcher.command("cancel") {
         val userId = message.from?.id ?: return@command
-        StateStorage.clear(userId)
+        StateStorageImpl.clearState(userId)
         TelegramApi.sendMessage(ChatId.fromId(userId), "Действие отменено. Вы в главном меню.")
         // Повторно вызываем /start, чтобы показать актуальное меню
         dispatcher.command("start")?.handler?.handleUpdate(bot, update)
@@ -26,7 +26,7 @@ fun addNavigationHandler(dispatcher: Dispatcher, userService: UserService) {
     dispatcher.callbackQuery(CallbackData.BACK_TO_MAIN_MENU) {
         val userId = callbackQuery.from.id
         val message = callbackQuery.message ?: return@callbackQuery
-        StateStorage.clear(userId)
+        StateStorageImpl.clearState(userId)
 
         // Удаляем предыдущее сообщение (например, меню клуба), чтобы не засорять чат
         bot.deleteMessage(ChatId.fromId(userId), message.messageId)

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/promoterHandlers.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/promoterHandlers.kt
@@ -5,7 +5,7 @@ import com.bookingbot.api.model.UserRole
 import com.bookingbot.api.services.ClubService
 import com.bookingbot.api.services.UserService
 import com.bookingbot.gateway.fsm.State
-import com.bookingbot.gateway.fsm.StateStorage
+import com.bookingbot.gateway.fsm.StateStorageImpl
 import com.bookingbot.gateway.util.StateFilter
 import com.github.kotlintelegrambot.dispatcher.Dispatcher
 import com.github.kotlintelegrambot.dispatcher.callbackQuery
@@ -30,7 +30,7 @@ fun addPromoterHandlers(dispatcher: Dispatcher, userService: UserService, clubSe
         }
 
         // Устанавливаем состояние ожидания имени гостя
-        StateStorage.setState(promoterId, State.PromoterGuestNameInput)
+        StateStorageImpl.saveState(promoterId, State.PromoterGuestNameInput)
         TelegramApi.sendMessage(
             chatId = ChatId.fromId(promoterId),
             text = "Вы начали создание брони для гостя. Пожалуйста, введите имя гостя:"
@@ -38,12 +38,12 @@ fun addPromoterHandlers(dispatcher: Dispatcher, userService: UserService, clubSe
     }
 
     // Шаг 2: Промоутер вводит имя гостя
-    dispatcher.message(Filter.Text and StateFilter(State.PromoterGuestNameInput.key)) {
+    dispatcher.message(Filter.Text and StateFilter(State.PromoterGuestNameInput)) {
         val promoterId = message.from?.id ?: return@message
         val guestName = message.text ?: return@message
         val promoter = userService.findOrCreateUser(promoterId, message.from?.username)
 
-        val context = StateStorage.getContext(promoterId)
+        val context = StateStorageImpl.getContext(promoterId)
         // Сохраняем имя гостя, ID промоутера и источник брони в контекст
         context.bookingGuestName = guestName
         context.promoterId = promoterId
@@ -62,6 +62,6 @@ fun addPromoterHandlers(dispatcher: Dispatcher, userService: UserService, clubSe
         )
 
         // Переводим промоутера в состояние выбора клуба, чтобы FSM гостя подхватил диалог
-        StateStorage.setState(promoterId, State.ClubSelection)
+        StateStorageImpl.saveState(promoterId, State.ClubSelection)
     }
 }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/util/StateFilter.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/util/StateFilter.kt
@@ -1,13 +1,14 @@
 package com.bookingbot.gateway.util
 
-import com.bookingbot.gateway.fsm.StateStorage
+import com.bookingbot.gateway.fsm.State
+import com.bookingbot.gateway.fsm.StateStorageImpl
 import com.github.kotlintelegrambot.entities.Message
 import com.github.kotlintelegrambot.extensions.filters.Filter
 
 // Этот класс-фильтр проверяет текущее состояние пользователя
-class StateFilter(private val state: String) : Filter {
+class StateFilter(private val state: State) : Filter {
     // Интерфейс Filter требует реализации только одного метода - predicate() для Message
     override fun Message.predicate(): Boolean {
-        return StateStorage.getState(chat.id) == state
+        return StateStorageImpl.getState(chat.id) == state
     }
 }


### PR DESCRIPTION
## Summary
- implement StateStorage interface with suspend functions
- provide non-blocking StateStorageImpl using Mutex
- update FSM handlers and StateFilter to use new API

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68851641ec28832180eaf1ad239c6205