### PR TITLE
Update bot-gateway Dockerfile

### DIFF
--- a/bot-gateway/Dockerfile
+++ b/bot-gateway/Dockerfile
@@ -1,11 +1,22 @@
-# 1) Берём готовый JDK 17 (multi-arch, без alpine)
-FROM eclipse-temurin:17-jdk
-
-# 2) Устанавливаем рабочую директорию
+# ---------- builder ----------
+FROM eclipse-temurin:17-jdk-alpine AS builder
 WORKDIR /app
+COPY gradlew gradlew
+COPY gradle gradle
+COPY build.gradle.kts settings.gradle.kts ./
+COPY src src
+RUN ./gradlew :bot-gateway:clean :bot-gateway:shadowJar --no-daemon
 
-# 3) Копируем собранный fat JAR (shadowJar) в контейнер
-COPY build/libs/bot-gateway-all.jar app.jar
+# ---------- runtime ----------
+FROM eclipse-temurin:17-jre-alpine
+LABEL maintainer="bookingbot team"
+ENV TZ=UTC
+WORKDIR /app
+COPY --from=builder /app/bot-gateway/build/libs/*.jar app.jar
 
-# 4) Точка входа
-ENTRYPOINT ["java", "-jar", "app.jar"]
+# Health-check endpoint exposed by Ktor
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD \
+  curl -f http://localhost:8080/health || exit 1
+
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]


### PR DESCRIPTION
## Summary
- use multi-stage build for bot-gateway image
- switch runtime to eclipse-temurin:17-jre-alpine
- add Ktor healthcheck

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve dependencies due to SSLInitializationException)*

------
https://chatgpt.com/codex/tasks/task_e_68851a72728c832185ac3b94b7b89c82