### PR TITLE
Add dependency scanning workflow and version catalog

### DIFF
--- a/.github/workflows/dependency-scanner.yml
+++ b/.github/workflows/dependency-scanner.yml
@@ -1,0 +1,19 @@
+name: Dependency Scanner
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  pull_request:
+    paths: ['**/*.gradle.kts', '**/libs.versions.toml']
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/gradle-build-action@v3
+        with:
+          arguments: dependencyCheckAnalyze
+      - uses: gradle/gradle-build-action@v3
+        with:
+          arguments: dependencyUpdates

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+## Security Checks
+* `./gradlew dependencyUpdates` — список более новых версий.
+* `./gradlew dependencyCheckAnalyze` — скан CVE (OWASP DC). При обнаружении High/CRITICAL сборка завершается.

--- a/booking-api/build.gradle.kts
+++ b/booking-api/build.gradle.kts
@@ -18,42 +18,37 @@ java {
 // repositories не нужен, наследуется из settings.gradle.kts
 
 dependencies {
-    // Версии из gradle.properties
-    val exposedVersion: String   by rootProject.extra
-    val flywayVersion: String    by rootProject.extra
-    val postgresVersion: String  by rootProject.extra
-
     // --- Exposed BOM + модули Exposed ---
     // Отличный подход — использовать BOM
-    implementation(platform("org.jetbrains.exposed:exposed-bom:$exposedVersion"))
-    implementation("org.jetbrains.exposed:exposed-core")
-    implementation("org.jetbrains.exposed:exposed-dao")
-    implementation("org.jetbrains.exposed:exposed-jdbc")
-    implementation("org.jetbrains.exposed:exposed-java-time")
+    implementation(platform(libs.exposed.bom))
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.dao)
+    implementation(libs.exposed.jdbc)
+    implementation(libs.exposed.java.time)
 
     // Flyway + Postgres
-    implementation("org.flywaydb:flyway-core:$flywayVersion")
-    runtimeOnly("org.postgresql:postgresql:$postgresVersion") // Драйвер БД лучше подключать как runtimeOnly
+    implementation(libs.flyway.core)
+    runtimeOnly(libs.postgresql) // Драйвер БД лучше подключать как runtimeOnly
 
     // HikariCP и конфигурация
-    implementation("com.zaxxer:HikariCP:5.0.1")
-    implementation("com.typesafe:config:1.4.3")
+    implementation(libs.hikaricp)
+    implementation(libs.typesafe.config)
 
     // dotenv
-    implementation("io.github.cdimascio:dotenv-kotlin:6.3.1")
+    implementation(libs.dotenv.kotlin)
 
     // Ktor panel for admin UI
-    implementation("io.ktor:ktor-server-core:2.3.+")
-    implementation("io.ktor:ktor-server-content-negotiation:2.3.+")
-    implementation("io.ktor:ktor-server-auth:2.3.+")
-    implementation("io.ktor-panel:ktor-panel:1.4.+")
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.server.auth)
+    implementation(libs.ktor.panel)
 
     // --- Тесты ---
     // Всё правильно, тестовые зависимости с `testImplementation`
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:${rootProject.extra["kotlinVersion"]}")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
-    testImplementation("com.h2database:h2:2.1.214") // H2 только для тестов
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.kotlin.test.junit5)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testImplementation(libs.h2) // H2 только для тестов
 }
 
 // Настройка компилятора Kotlin

--- a/bot-gateway/build.gradle.kts
+++ b/bot-gateway/build.gradle.kts
@@ -29,56 +29,52 @@ kotlin {
 
 // Блок repositories здесь не нужен, так как он централизован в settings.gradle.kts
 
-// подтягиваем переменные, которые объявлены в root gradle.properties
-val ktorVersion: String by project
-val coroutinesVersion: String by project
-
 dependencies {
     implementation(project(":booking-api"))
 
     // Ktor
-    implementation(platform("io.ktor:ktor-bom:$ktorVersion"))
-    implementation("io.ktor:ktor-server-core-jvm")
-    implementation("io.ktor:ktor-server-netty-jvm")
-    implementation("io.ktor:ktor-server-content-negotiation-jvm")
-    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm")
-    implementation("io.ktor:ktor-server-auth-jvm")
-    implementation("io.ktor:ktor-server-auth-jwt-jvm")
-    implementation("io.ktor:ktor-server-auth-jwt:2.3.+")
-    implementation("com.auth0:java-jwt:4.4.0")
+    implementation(platform(libs.ktor.bom))
+    implementation(libs.ktor.server.core.jvm)
+    implementation(libs.ktor.server.netty.jvm)
+    implementation(libs.ktor.server.content.negotiation.jvm)
+    implementation(libs.ktor.serialization.kotlinx.json.jvm)
+    implementation(libs.ktor.server.auth.jvm)
+    implementation(libs.ktor.server.auth.jwt.jvm)
+    implementation(libs.ktor.server.auth.jwt)
+    implementation(libs.java.jwt)
 
     // Koin
-    implementation("io.insert-koin:koin-ktor:3.6.0")
-    implementation("io.insert-koin:koin-logger-slf4j:3.6.0")
-    testImplementation("io.insert-koin:koin-test:3.6.0")
+    implementation(libs.koin.ktor)
+    implementation(libs.koin.logger.slf4j)
+    testImplementation(libs.koin.test)
 
     // Telegram Bot, без тянущихся артефактов Ktor
-    implementation("io.github.kotlin-telegram-bot:kotlin-telegram-bot:6.3.0") {
+    implementation(libs.telegram.bot) {
         exclude(group = "io.ktor")
     }
 
     // centralized logging backend
-    implementation("ch.qos.logback:logback-classic:1.4.11")
+    implementation(libs.logback.classic)
 
     // В H2 нам нужен только для тестов в этом модуле
-    testImplementation("com.h2database:h2:2.1.214")
+    testImplementation(libs.h2)
 
     // Coroutines
-    implementation(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:$coroutinesVersion"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
+    implementation(platform(libs.coroutines.bom))
+    implementation(libs.coroutines.core)
+    testImplementation(libs.coroutines.test)
 
     // Тестовый Ktor
-    testImplementation(platform("io.ktor:ktor-bom:$ktorVersion"))
-    testImplementation("io.ktor:ktor-server-test-host-jvm")
-    testImplementation("io.ktor:ktor-client-cio")
-    testImplementation("io.ktor:ktor-client-content-negotiation")
-    testImplementation("io.ktor:ktor-serialization-kotlinx-json")
+    testImplementation(platform(libs.ktor.bom))
+    testImplementation(libs.ktor.server.test.host.jvm)
+    testImplementation(libs.ktor.client.cio)
+    testImplementation(libs.ktor.client.content.negotiation)
+    testImplementation(libs.ktor.serialization.kotlinx.json)
 
     // JUnit5 + Kotlin Test
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:1.9.23") // Явно указал версию для стабильности
-    testImplementation("io.ktor:ktor-client-mock:2.3.+")
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.kotlin.test.junit5) // Явно указал версию для стабильности
+    testImplementation(libs.ktor.client.mock)
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,11 @@ plugins {
     kotlin("jvm") apply false
     id("org.jetbrains.kotlin.plugin.serialization") apply false
     id("io.ktor.plugin") apply false
+    id("com.github.ben-manes.versions") version "0.51.0"
+    id("org.owasp.dependencycheck") version "9.2.0"
+}
+
+tasks.named<org.owasp.dependencycheck.gradle.extension.DependencyCheckTask>("dependencyCheckAnalyze") {
+    failBuildOnCVSS = 7.0F
+    suppressionFile = "dependency-check-suppressions.xml"
 }

--- a/buildSrc/libs.versions.toml
+++ b/buildSrc/libs.versions.toml
@@ -1,0 +1,65 @@
+[versions]
+kotlin = "1.9.23"
+ktor = "2.3.+"
+telegrambot = "6.1.0"
+coroutines = "1.7.3"
+exposed = "0.50.0"
+flyway = "10.14.0"
+postgres = "42.7.3"
+hikaricp = "5.0.1"
+config = "1.4.3"
+dotenv = "6.3.1"
+ktorPanel = "1.4.+"
+logback = "1.4.11"
+koin = "3.6.0"
+jwt = "4.4.0"
+h2 = "2.1.214"
+junit = "5.10.0"
+
+[libraries]
+exposed-bom = { module = "org.jetbrains.exposed:exposed-bom", version.ref = "exposed" }
+exposed-core = { module = "org.jetbrains.exposed:exposed-core" }
+exposed-dao = { module = "org.jetbrains.exposed:exposed-dao" }
+exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc" }
+exposed-java-time = { module = "org.jetbrains.exposed:exposed-java-time" }
+
+flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgres" }
+hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp" }
+typesafe-config = { module = "com.typesafe:config", version.ref = "config" }
+dotenv-kotlin = { module = "io.github.cdimascio:dotenv-kotlin", version.ref = "dotenv" }
+
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
+ktor-panel = { module = "io.ktor-panel:ktor-panel", version.ref = "ktorPanel" }
+
+kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+
+h2 = { module = "com.h2database:h2", version.ref = "h2" }
+java-jwt = { module = "com.auth0:java-jwt", version.ref = "jwt" }
+koin-ktor = { module = "io.insert-koin:koin-ktor", version.ref = "koin" }
+koin-logger-slf4j = { module = "io.insert-koin:koin-logger-slf4j", version.ref = "koin" }
+koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
+telegram-bot = { module = "io.github.kotlin-telegram-bot:kotlin-telegram-bot", version.ref = "telegrambot" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "coroutines" }
+coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test" }
+
+ktor-bom = { module = "io.ktor:ktor-bom", version.ref = "ktor" }
+ktor-server-core-jvm = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
+ktor-server-netty-jvm = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }
+ktor-server-content-negotiation-jvm = { module = "io.ktor:ktor-server-content-negotiation-jvm", version.ref = "ktor" }
+ktor-serialization-kotlinx-json-jvm = { module = "io.ktor:ktor-serialization-kotlinx-json-jvm", version.ref = "ktor" }
+ktor-server-auth-jvm = { module = "io.ktor:ktor-server-auth-jvm", version.ref = "ktor" }
+ktor-server-auth-jwt-jvm = { module = "io.ktor:ktor-server-auth-jwt-jvm", version.ref = "ktor" }
+ktor-server-auth-jwt = { module = "io.ktor:ktor-server-auth-jwt", version.ref = "ktor" }
+ktor-server-test-host-jvm = { module = "io.ktor:ktor-server-test-host-jvm", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,11 @@ dependencyResolutionManagement {
         mavenCentral()
         maven("https://jitpack.io")
     }
+    versionCatalogs {
+        create("libs") {
+            from(files("buildSrc/libs.versions.toml"))
+        }
+    }
 }
 rootProject.name = "booking_bot"
 // Bot module requires external dependencies from JitPack which are not


### PR DESCRIPTION
## Summary
- centralize dependency versions in `buildSrc/libs.versions.toml`
- use catalog aliases in Gradle modules
- add Versions and OWASP DC plugins to root build
- schedule weekly dependency/CVE scan workflow
- document security checks in README

## Testing
- `./gradlew dependencyUpdates` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885250c23848321a360a451f9ef61c7