### PR TITLE
Migrate FSM storage to Redis

### DIFF
--- a/bot-gateway/build.gradle.kts
+++ b/bot-gateway/build.gradle.kts
@@ -55,9 +55,13 @@ dependencies {
 
     // centralized logging backend
     implementation(libs.logback.classic)
+    implementation(libs.lettuce.core)
+    implementation(libs.kotlinx.serialization.json)
 
     // В H2 нам нужен только для тестов в этом модуле
     testImplementation(libs.h2)
+    testImplementation(libs.jedis)
+    testImplementation(libs.embedded.redis)
 
     // Coroutines
     implementation(platform(libs.coroutines.bom))

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/DiConfig.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/DiConfig.kt
@@ -3,6 +3,8 @@ package com.bookingbot.gateway
 import com.bookingbot.api.DatabaseFactory
 import com.bookingbot.api.services.BookingService
 import io.ktor.server.application.Application
+import com.bookingbot.gateway.fsm.RedisStateStorage
+import com.bookingbot.gateway.fsm.StateStorage
 import org.koin.dsl.module
 import org.koin.ktor.plugin.Koin
 import org.koin.logger.slf4jLogger
@@ -15,6 +17,11 @@ import org.koin.core.module.dsl.singleOf
 val appModule = module {
     single { DatabaseFactory }
     single { BookingService() }
+    single<StateStorage> {
+        RedisStateStorage(
+            redisUrl = environment.config.property("redis.url").getString()
+        )
+    }
 }
 
 /**

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/fsm/RedisStateStorage.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/fsm/RedisStateStorage.kt
@@ -1,0 +1,40 @@
+package com.bookingbot.gateway.fsm
+
+import io.lettuce.core.RedisClient
+import io.lettuce.core.api.coroutines
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import java.util.concurrent.ConcurrentHashMap
+
+class RedisStateStorage(
+    redisUrl: String,
+    private val ttlSeconds: Long = 86_400
+) : StateStorage {
+
+    private val client = RedisClient.create(redisUrl)
+    private val connection = client.connect().coroutines()
+
+    private val mutex = Mutex() // only for connection reauth if needed
+    private val contexts = ConcurrentHashMap<Long, BookingContext>()
+
+    override suspend fun saveState(chatId: Long, state: State) {
+        val key = "fsm:$chatId"
+        connection.setex(key, ttlSeconds, Json.encodeToString(state))
+    }
+
+    override suspend fun getState(chatId: Long): State? =
+        connection.get("fsm:$chatId")?.let { Json.decodeFromString<State>(it) }
+
+    override suspend fun getContext(chatId: Long): BookingContext =
+        mutex.withLock { contexts.getOrPut(chatId) { BookingContext() } }
+
+    override suspend fun clearState(chatId: Long) {
+        connection.del("fsm:$chatId")
+        mutex.withLock { contexts.remove(chatId) }
+    }
+
+    fun close() = connection.close()
+}

--- a/bot-gateway/src/main/resources/application.conf
+++ b/bot-gateway/src/main/resources/application.conf
@@ -17,3 +17,7 @@ basic {
   user  = ${?BASIC_USER}
   pass  = ${?BASIC_PASS}
 }
+
+redis {
+  url = ${?REDIS_URL}
+}

--- a/bot-gateway/src/test/kotlin/com/bookingbot/gateway/fsm/StateStorageTest.kt
+++ b/bot-gateway/src/test/kotlin/com/bookingbot/gateway/fsm/StateStorageTest.kt
@@ -1,0 +1,45 @@
+package com.bookingbot.gateway.fsm
+
+import redis.embedded.RedisServer
+import redis.embedded.RedisServerBuilder
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class StateStorageTest {
+    private lateinit var server: RedisServer
+    private lateinit var storage: RedisStateStorage
+    private val port = 6379
+
+    @BeforeEach
+    fun setUp() {
+        server = RedisServerBuilder().port(port).build()
+        server.start()
+        storage = RedisStateStorage("redis://localhost:$port/0", ttlSeconds = 1)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        storage.close()
+        server.stop()
+    }
+
+    @Test
+    fun saveGetClearRoundTrip() = runTest {
+        storage.saveState(1L, State.ClubSelection)
+        assertEquals(State.ClubSelection, storage.getState(1L))
+        storage.clearState(1L)
+        assertNull(storage.getState(1L))
+    }
+
+    @Test
+    fun ttlExpires() = runTest {
+        storage.saveState(2L, State.DateSelection)
+        delay(1500)
+        assertNull(storage.getState(2L))
+    }
+}

--- a/buildSrc/libs.versions.toml
+++ b/buildSrc/libs.versions.toml
@@ -18,6 +18,10 @@ junit = "5.10.0"
 mockito = "5.9.0"
 mockitoKotlin = "5.2.1"
 wiremock = "3.3.1"
+lettuce = "6.3.3.RELEASE"
+serializationJson = "1.6.3"
+jedis = "5.2.0"
+embeddedRedis = "0.7.3"
 
 [libraries]
 exposed-bom = { module = "org.jetbrains.exposed:exposed-bom", version.ref = "exposed" }
@@ -71,3 +75,7 @@ ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+lettuce-core = { module = "io.lettuce:lettuce-core", version.ref = "lettuce" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serializationJson" }
+jedis = { module = "redis.clients:jedis", version.ref = "jedis" }
+embedded-redis = { module = "it.ozimov:embedded-redis", version.ref = "embeddedRedis" }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,11 @@ services:
     ports:
       - "8081:8080"
 
+  redis:
+    image: redis:7-alpine
+    ports: ["6379:6379"]
+    command: ["redis-server", "--save", "60", "1"]
+
 # Определение томов для хранения данных
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary
- add RedisStateStorage and wire via DI
- support Redis config in `application.conf`
- include Redis service in `docker-compose.yml`
- extend build with lettuce, serialization-json and test libs
- add tests for Redis state storage

## Testing
- `gradle test` *(fails: Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_688563b5a41c8321a56d56c2a015e112