### PR TITLE
Integrate Ktor rate-limiting and request validation

### DIFF
--- a/bot-gateway/build.gradle.kts
+++ b/bot-gateway/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
     implementation(libs.ktor.server.auth.jvm)
     implementation(libs.ktor.server.auth.jwt.jvm)
     implementation(libs.ktor.server.auth.jwt)
+    implementation("io.ktor:ktor-server-rate-limit:3.2.2")
+    implementation("io.ktor:ktor-server-request-validation:3.2.2")
     implementation(libs.java.jwt)
 
     // Koin
@@ -80,6 +82,8 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.kotlin.test.junit5) // Явно указал версию для стабильности
     testImplementation(libs.ktor.client.mock)
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:5.9.0")
+    testImplementation("io.kotest:kotest-assertions-core-jvm:5.9.0")
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Application.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Application.kt
@@ -3,6 +3,18 @@ package com.bookingbot.gateway
 import io.ktor.server.application.Application
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
+import io.ktor.server.plugins.ratelimit.RateLimit
+import io.ktor.server.plugins.ratelimit.RateLimitExceededException
+import io.ktor.server.plugins.requestvalidation.RequestValidation
+import io.ktor.server.plugins.requestvalidation.RequestValidationException
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.response.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
+import security.ValidationRules
+import com.bookingbot.gateway.GuestDTO
+import com.bookingbot.gateway.RateLimitConfig
+import com.bookingbot.api.model.booking.BookingRequest
 import com.bookingbot.gateway.waitlist.WaitlistScheduler
 import java.time.Duration
 import org.koin.ktor.ext.get
@@ -21,6 +33,26 @@ fun Application.module() {
     val scheduler = WaitlistScheduler(get(), Duration.ofMinutes(1))
     scheduler.start()
     configureAuth()
+    val rateLimitConf = RateLimitConfig.load()
+    install(RateLimit) {
+        global { limit(window = rateLimitConf.window, maxRequests = rateLimitConf.requests) }
+    }
+    install(RequestValidation) {
+        validate<String> { ValidationRules.validatePhone(it) }
+        validate<GuestDTO> { ValidationRules.validateGuestName(it.name) }
+        validate<BookingRequest> {
+            it.phone?.let { p -> ValidationRules.validatePhone(p) }
+            it.bookingGuestName?.let { n -> ValidationRules.validateGuestName(n) }
+        }
+    }
+    install(StatusPages) {
+        exception<RequestValidationException> { call, _ ->
+            call.respond(HttpStatusCode.BadRequest)
+        }
+        exception<RateLimitExceededException> { call, _ ->
+            call.respond(HttpStatusCode.TooManyRequests)
+        }
+    }
     configureMetrics()
     configureRouting()
 }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/GuestDTO.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/GuestDTO.kt
@@ -1,0 +1,1 @@
+data class GuestDTO(val name: String)

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/RateLimitConfig.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/RateLimitConfig.kt
@@ -1,0 +1,22 @@
+package com.bookingbot.gateway
+
+import com.typesafe.config.ConfigFactory
+import java.time.Duration
+
+/**
+ * Configuration for rate limiting.
+ */
+data class RateLimitConfig(
+    val window: Duration,
+    val requests: Int
+) {
+    companion object {
+        fun load(): RateLimitConfig {
+            val cfg = ConfigFactory.load().getConfig("security.rateLimit")
+            return RateLimitConfig(
+                window = cfg.getDuration("window"),
+                requests = cfg.getInt("requests")
+            )
+        }
+    }
+}

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Routing.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Routing.kt
@@ -25,6 +25,11 @@ fun Application.configureRouting() {
     routing {
         val service: BookingService by inject()
 
+        post("/booking") {
+            val dto = call.receive<BookingRequest>()
+            call.respond(service.createBooking(dto))
+        }
+
         // /bookings — RBA (Security)
         authorize(Role.ADMIN, Role.USER) {
             get("/bookings") {

--- a/bot-gateway/src/main/kotlin/security/Validation.kt
+++ b/bot-gateway/src/main/kotlin/security/Validation.kt
@@ -1,0 +1,22 @@
+package security
+
+import io.ktor.server.plugins.requestvalidation.ValidationException
+
+/**
+ * Collection of validation helper functions.
+ */
+object ValidationRules {
+    private val phoneRegex = Regex("^\\+?\\d{10,14}$")
+
+    fun validatePhone(phone: String) {
+        if (!phoneRegex.matches(phone)) {
+            throw ValidationException("Invalid phone format")
+        }
+    }
+
+    fun validateGuestName(name: String) {
+        if (name.isBlank()) {
+            throw ValidationException("Guest name is blank")
+        }
+    }
+}

--- a/bot-gateway/src/main/resources/application.conf
+++ b/bot-gateway/src/main/resources/application.conf
@@ -28,3 +28,10 @@ basic {
 redis {
   url = ${?REDIS_URL}
 }
+
+security {
+  rateLimit {
+    window = 1m
+    requests = 60
+  }
+}

--- a/bot-gateway/src/test/kotlin/com/bookingbot/gateway/RateLimitAndValidationTest.kt
+++ b/bot-gateway/src/test/kotlin/com/bookingbot/gateway/RateLimitAndValidationTest.kt
@@ -1,0 +1,47 @@
+package com.bookingbot.gateway
+
+import com.bookingbot.api.model.booking.BookingRequest
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import java.time.Instant
+
+class RateLimitAndValidationTest : StringSpec({
+    "testRateLimitExceeded" {
+        testApplication {
+            application { module() }
+            val client = createClient { install(ContentNegotiation) { json() } }
+            val req = BookingRequest(1,1,1,Instant.EPOCH,1,bookingGuestName="G",telegramId=1,phone="+12345678901",bookingSource="test")
+            repeat(60) {
+                client.post("/booking") {
+                    contentType(ContentType.Application.Json)
+                    setBody(req)
+                }
+            }
+            val resp = client.post("/booking") {
+                contentType(ContentType.Application.Json)
+                setBody(req)
+            }
+            resp.status shouldBe HttpStatusCode.TooManyRequests
+        }
+    }
+
+    "testInvalidPhoneReturns400" {
+        testApplication {
+            application { module() }
+            val client = createClient { install(ContentNegotiation) { json() } }
+            val req = BookingRequest(1,1,1,Instant.EPOCH,1,bookingGuestName="G",telegramId=1,phone="bad",bookingSource="test")
+            val resp = client.post("/booking") {
+                contentType(ContentType.Application.Json)
+                setBody(req)
+            }
+            resp.status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- add Ktor `rate-limit` and `request-validation` dependencies
- configure security settings in `application.conf`
- add helpers for validation and rate limit config
- install RateLimit, RequestValidation and StatusPages
- expose simple `/booking` endpoint
- add Kotest tests for rate limits and bad phone numbers

## Testing
- `./gradlew :bot-gateway:test --no-daemon -q` *(fails: toolchain 17 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68856c203c9883219b6002ff142c69cc