### PR TITLE
Add health checks and Prometheus metrics

### DIFF
--- a/bot-gateway/Dockerfile
+++ b/bot-gateway/Dockerfile
@@ -12,7 +12,7 @@ FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app
 COPY --from=builder /app/bot-gateway/build/libs/*.jar app.jar
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD wget -qO- http://localhost:8080/health || exit 1
+HEALTHCHECK --interval=15s CMD curl -f http://localhost:8080/healthz || exit 1
 
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/bot-gateway/build.gradle.kts
+++ b/bot-gateway/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
     implementation("io.ktor:ktor-server-rate-limit:3.2.2")
     implementation("io.ktor:ktor-server-request-validation:3.2.2")
     implementation(libs.java.jwt)
+    implementation("io.micrometer:micrometer-registry-prometheus:1.12.+")
+    implementation("io.ktor:ktor-server-micrometer:3.2.2")
+    implementation("com.github.zensum:ktor-health-check:0.2.0")
 
     // Koin
     implementation(libs.koin.ktor)

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Application.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Application.kt
@@ -54,5 +54,6 @@ fun Application.module() {
         }
     }
     configureMetrics()
+    configureHealth()
     configureRouting()
 }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/HealthModule.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/HealthModule.kt
@@ -1,0 +1,27 @@
+package com.bookingbot.gateway
+
+import io.ktor.server.application.*
+import io.micrometer.core.instrument.Timer
+import io.micrometer.prometheus.PrometheusMeterRegistry
+import ktor_health_check.Health
+import org.koin.ktor.ext.get
+import java.util.concurrent.TimeUnit
+
+private data class HealthConf(
+    val latencyMaxMs: Long
+)
+
+fun Application.configureHealth(promRegistry: PrometheusMeterRegistry = com.bookingbot.gateway.promRegistry) {
+    val conf = HealthConf(
+        latencyMaxMs = environment.config.property("health.latency.max").getString().toLong()
+    )
+    install(Health) {
+        readyCheck("postgres") { runCatching { DatabaseFactory.exists("bookings") }.getOrDefault(false) }
+        readyCheck("redis") { runCatching { get<com.bookingbot.gateway.fsm.RedisStateStorage>().ping() == "PONG" }.getOrDefault(false) }
+        readyCheck("latency") {
+            val timer = promRegistry.find("http.server.requests").timer()
+            val p95 = timer?.percentile(0.95, TimeUnit.MILLISECONDS) ?: Double.NaN
+            !p95.isNaN() && p95 < conf.latencyMaxMs
+        }
+    }
+}

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Metrics.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Metrics.kt
@@ -5,18 +5,41 @@ import io.ktor.server.metrics.micrometer.MicrometerMetrics
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig
 import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
+import java.time.Duration
 
 val promRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
 
 fun Application.configureMetrics() {
     install(MicrometerMetrics) {
         registry = promRegistry
-        distributionStatisticConfig = DistributionStatisticConfig.DEFAULT
+        distributionStatisticConfig = DistributionStatisticConfig.DEFAULT.merge(
+            DistributionStatisticConfig.builder()
+                .percentilesHistogram(true)
+                .percentiles(0.95, 0.99)
+                .serviceLevelObjectives(
+                    Duration.ofMillis(50),
+                    Duration.ofMillis(100),
+                    Duration.ofMillis(200),
+                    Duration.ofMillis(500),
+                    Duration.ofSeconds(1),
+                    Duration.ofSeconds(2)
+                )
+                .build()
+        )
     }
     routing {
         get("/metrics") { call.respondText(promRegistry.scrape()) }
+    }
+    environment.config.propertyOrNull("monitoring.prometheus.port")?.getString()?.toInt()?.let { port ->
+        embeddedServer(Netty, port = port, host = "0.0.0.0") {
+            routing {
+                get("/metrics") { call.respondText(promRegistry.scrape()) }
+            }
+        }.start(wait = false)
     }
 }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/fsm/RedisStateStorage.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/fsm/RedisStateStorage.kt
@@ -36,5 +36,7 @@ class RedisStateStorage(
         mutex.withLock { contexts.remove(chatId) }
     }
 
+    suspend fun ping(): String = connection.ping()
+
     fun close() = connection.close()
 }

--- a/bot-gateway/src/main/resources/application.conf
+++ b/bot-gateway/src/main/resources/application.conf
@@ -35,3 +35,11 @@ security {
     requests = 60
   }
 }
+monitoring {
+  prometheus.port = 8081
+}
+health {
+  db.timeout = 1000
+  redis.timeout = 500
+  latency.max = 500
+}

--- a/bot-gateway/src/test/kotlin/com/bookingbot/gateway/HealthModuleTest.kt
+++ b/bot-gateway/src/test/kotlin/com/bookingbot/gateway/HealthModuleTest.kt
@@ -1,0 +1,35 @@
+package com.bookingbot.gateway
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import ktor_health_check.Health
+
+class HealthModuleTest : StringSpec({
+    "readyz returns 200 when checks pass" {
+        testApplication {
+            application {
+                install(Health) {
+                    readyCheck("db") { true }
+                    readyCheck("redis") { true }
+                }
+            }
+            val resp = client.get("/readyz")
+            resp.status shouldBe HttpStatusCode.OK
+        }
+    }
+
+    "readyz returns 503 when any check fails" {
+        testApplication {
+            application {
+                install(Health) {
+                    readyCheck("db") { true }
+                    readyCheck("redis") { false }
+                }
+            }
+            val resp = client.get("/readyz")
+            resp.status shouldBe HttpStatusCode.ServiceUnavailable
+        }
+    }
+})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,11 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "$POSTGRES_USER"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
 
   bot-gateway:
     build:
@@ -25,10 +30,13 @@ services:
     environment:
       TELEGRAM_BOT_TOKEN_FILE: /run/secrets/tg_token
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     ports:
       - "8080:8080"
-
+      
   booking-api:
     build:
       context: ./booking-api
@@ -42,6 +50,10 @@ services:
     image: redis:7-alpine
     ports: ["6379:6379"]
     command: ["redis-server", "--save", "60", "1"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
 
 # Определение томов для хранения данных
 volumes:

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,4 @@ coroutinesVersion=1.7.3
 exposedVersion=0.50.0
 flywayVersion=10.14.0
 postgresVersion=42.7.3
+org.gradle.java.installations.auto-download=true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,6 +1,6 @@
 scrape_configs:
   - job_name: 'bot-gateway'
-    static_configs: [{ targets: ['bot-gateway:8080'] }]
+    static_configs: [{ targets: ['bot-gateway:8081'] }]
   - job_name: 'booking-api'
     static_configs: [{ targets: ['booking-api:8081'] }]
 alerting:


### PR DESCRIPTION
## Summary
- install Micrometer Prometheus registry and ktor-health-check
- expose health checks for Postgres, Redis and latency
- serve metrics with histogram buckets
- provide health endpoints and docker-compose health checks
- test readiness behaviour

## Testing
- `./gradlew test` *(fails: Could not resolve io.ktor-panel from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68856f50352883218d001c242afec0e1