### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: Test & Lint
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_PASSWORD: test
+        ports: ['5432:5432']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/gradle-build-action@v3
+        with:
+          arguments: test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 .PHONY: build test run lint fmt
 build: ; ./gradlew clean build
 
-test:  ; ./gradlew test
+test-unit: ; ./gradlew :bot-gateway:test --tests "*unit.*"
+test-integration: ; ./gradlew :bot-gateway:test --tests "*integration.*"
+test-e2e: ; ./gradlew :bot-gateway:test --tests "*e2e.*"
+test: test-unit test-integration test-e2e
 
 run:   ; ./gradlew :bot-gateway:run
 

--- a/bot-gateway/src/test/kotlin/com/bookingbot/gateway/e2e/BotConversationE2ETest.kt
+++ b/bot-gateway/src/test/kotlin/com/bookingbot/gateway/e2e/BotConversationE2ETest.kt
@@ -1,0 +1,31 @@
+package com.bookingbot.gateway.e2e
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.WireMockServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+@Disabled("Requires Telegram Test API")
+class BotConversationE2ETest {
+    private lateinit var server: WireMockServer
+
+    @BeforeEach
+    fun setup() {
+        server = WireMockServer(WireMockConfiguration.wireMockConfig().port(12100))
+        server.start()
+        server.stubFor(WireMock.post(WireMock.urlPathMatching("/bot.*/sendMessage")).willReturn(WireMock.okJson("{}")))
+        server.stubFor(WireMock.post(WireMock.urlPathMatching("/bot.*/sendPhoto")).willReturn(WireMock.okJson("{}")))
+    }
+
+    @AfterEach
+    fun teardown() { server.stop() }
+
+    @Test
+    fun dialog() {
+        // Real bot startup skipped; verify stubs registered
+        server.verify(0, WireMock.postRequestedFor(WireMock.urlMatching("/bot.*/sendMessage")))
+    }
+}

--- a/bot-gateway/src/test/kotlin/com/bookingbot/gateway/integration/BookingApiIntegrationTest.kt
+++ b/bot-gateway/src/test/kotlin/com/bookingbot/gateway/integration/BookingApiIntegrationTest.kt
@@ -1,0 +1,47 @@
+package com.bookingbot.gateway.integration
+
+import com.bookingbot.api.DatabaseFactory
+import com.bookingbot.api.model.booking.BookingRequest
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import java.time.Instant
+import java.util.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BookingApiIntegrationTest {
+    @Test
+    fun `create and fetch booking`() = testApplication {
+        environment {
+            systemProperties["DB_URL"] = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1"
+            systemProperties["BASIC_USER"] = "admin"
+            systemProperties["BASIC_PASS"] = "pass"
+            systemProperties["JWT_SECRET"] = "secret"
+        }
+        application { com.bookingbot.gateway.Application().module() }
+        DatabaseFactory.init()
+        val client = createClient {
+            install(ContentNegotiation) { json() }
+        }
+        val req = BookingRequest(1,1,1,Instant.EPOCH,1,60,"G",123,"+1",null,"test")
+        val auth = "Basic " + Base64.getEncoder().encodeToString("admin:pass".toByteArray())
+        val resp = client.post("/bookings") {
+            header(HttpHeaders.Authorization, auth)
+            contentType(ContentType.Application.Json)
+            setBody(req)
+        }
+        assertEquals(HttpStatusCode.Created, resp.status)
+        val created = resp.body<com.bookingbot.api.model.booking.Booking>()
+        val get = client.get("/bookings/${'$'}{created.id}") { header(HttpHeaders.Authorization, auth) }
+        assertEquals(HttpStatusCode.OK, get.status)
+    }
+}

--- a/bot-gateway/src/test/kotlin/com/bookingbot/gateway/integration/WaitlistIntegrationTest.kt
+++ b/bot-gateway/src/test/kotlin/com/bookingbot/gateway/integration/WaitlistIntegrationTest.kt
@@ -1,0 +1,42 @@
+package com.bookingbot.gateway.integration
+
+import com.bookingbot.api.DatabaseFactory
+import com.bookingbot.api.model.booking.BookingRequest
+import com.bookingbot.api.services.BookingService
+import com.bookingbot.api.services.WaitlistDao
+import com.bookingbot.gateway.waitlist.WaitlistNotifierImpl
+import io.ktor.server.testing.testApplication
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WaitlistIntegrationTest {
+    @Test
+    fun `cancel booking updates waitlist`() = testApplication {
+        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:15-alpine"))
+        pg.start()
+        environment {
+            systemProperties["DB_URL"] = pg.jdbcUrl
+            systemProperties["DB_USER"] = pg.username
+            systemProperties["DB_PASSWORD"] = pg.password
+            systemProperties["JWT_SECRET"] = "secret"
+            systemProperties["BASIC_USER"] = "a"
+            systemProperties["BASIC_PASS"] = "b"
+        }
+        DatabaseFactory.init()
+        val service = BookingService()
+        val notifier = WaitlistNotifierImpl(service, com.bookingbot.api.services.TableService())
+        com.bookingbot.api.services.WaitlistNotifierHolder.notifier = notifier
+        val entry = WaitlistDao.addEntry(1, Instant.EPOCH, 1)
+        val booking = service.createBooking(
+            BookingRequest(1,1,1,Instant.EPOCH,1,60,"g",1,"+1",null,"test")
+        )
+        service.cancelBooking(booking.id, 1)
+        notifier.scanWaitlist()
+        val updated = WaitlistDao.getEntry(entry.id)!!
+        assertEquals("OFFERED", updated.status)
+        pg.stop()
+    }
+}

--- a/bot-gateway/src/test/kotlin/com/bookingbot/gateway/unit/BookingServiceTest.kt
+++ b/bot-gateway/src/test/kotlin/com/bookingbot/gateway/unit/BookingServiceTest.kt
@@ -1,0 +1,48 @@
+package com.bookingbot.gateway.unit
+
+import com.bookingbot.api.DatabaseFactory
+import com.bookingbot.api.model.booking.BookingRequest
+import com.bookingbot.api.services.BookingService
+import com.bookingbot.api.services.WaitlistNotifier
+import com.bookingbot.api.services.WaitlistNotifierHolder
+import com.bookingbot.gateway.TelegramApi
+import com.github.kotlintelegrambot.entities.ChatId
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertTrue
+
+class BookingServiceTest {
+    @Test
+    fun `create booking sends telegram message`() = runTest {
+        DatabaseFactory.init()
+        mockkObject(TelegramApi)
+        val msgResp = mockk<com.github.kotlintelegrambot.network.Response<com.github.kotlintelegrambot.entities.Message>>(relaxed = true)
+        io.mockk.every { TelegramApi.sendMessage(any(), any(), any(), any(), any()) } returns msgResp
+        WaitlistNotifierHolder.notifier = object : WaitlistNotifier {
+            override fun onNewBooking() { TelegramApi.sendMessage(ChatId.fromId(1), "ok") }
+            override fun onCancel() {}
+        }
+        val service = BookingService()
+        val booking = service.createBooking(
+            BookingRequest(
+                userId = 1,
+                clubId = 1,
+                tableId = 1,
+                bookingTime = Instant.EPOCH,
+                partySize = 2,
+                expectedDuration = 60,
+                bookingGuestName = "A",
+                telegramId = 1,
+                phone = "+10000000000",
+                promoterId = null,
+                bookingSource = "test"
+            )
+        )
+        assertTrue(booking.id > 0)
+        verify { TelegramApi.sendMessage(any(), any(), any(), any(), any()) }
+    }
+}

--- a/bot-gateway/src/test/kotlin/com/bookingbot/gateway/unit/HallSchemeRendererTest.kt
+++ b/bot-gateway/src/test/kotlin/com/bookingbot/gateway/unit/HallSchemeRendererTest.kt
@@ -1,0 +1,43 @@
+package com.bookingbot.gateway.unit
+
+import com.bookingbot.gateway.hall.HallSchemeRenderer
+import com.typesafe.config.ConfigFactory
+import kotlinx.coroutines.test.runTest
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HallSchemeRendererTest {
+    private fun template(path: String): BufferedImage {
+        val img = BufferedImage(200, 200, BufferedImage.TYPE_INT_ARGB)
+        ImageIO.write(img, "png", File(path))
+        return img
+    }
+
+    @Test
+    fun `render keeps size`() = runTest {
+        val file = File.createTempFile("tpl", ".png")
+        val tpl = template(file.absolutePath)
+        val cfg = ConfigFactory.parseMap(mapOf("bot.hallSchemePath" to file.absolutePath))
+        val renderer = HallSchemeRenderer(cfg)
+        val outBytes = renderer.render(emptyList())
+        val out = ImageIO.read(outBytes.inputStream())
+        assertEquals(tpl.width, out.width)
+        assertEquals(tpl.height, out.height)
+    }
+
+    @Test
+    fun `green pixel when table free`() = runTest {
+        val file = File.createTempFile("tpl", ".png")
+        template(file.absolutePath)
+        val cfg = ConfigFactory.parseMap(mapOf("bot.hallSchemePath" to file.absolutePath))
+        val renderer = HallSchemeRenderer(cfg)
+        val out = ImageIO.read(renderer.render(listOf(1)).inputStream())
+        val color = Color(out.getRGB(80, 80))
+        assertTrue(color.green > 150)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // build.gradle.kts (root)
 
 plugins {
-    kotlin("jvm") apply false
+    kotlin("jvm")
     id("org.jetbrains.kotlin.plugin.serialization") apply false
     id("io.ktor.plugin") apply false
     id("com.github.ben-manes.versions") version "0.51.0"
@@ -14,4 +14,21 @@ dependencyCheck {
     failBuildOnCVSS = 7.0F
     suppressionFiles = listOf("dependency-check-suppressions.xml")
 }
+
+dependencies {
+    // --- unit ---
+    testImplementation("io.mockk:mockk:1.13.9")
+    testImplementation("io.kotest:kotest-assertions-core:5.8.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+
+    // --- integration ---
+    testImplementation("io.ktor:ktor-server-test-host:2.3.+")
+    testImplementation("org.testcontainers:postgresql:1.19.1")
+    testImplementation("com.h2database:h2:2.2.224")
+
+    // --- E2E ---
+    testImplementation("com.github.tomakehurst:wiremock-jre8:3.3.1")
+}
+
+tasks.test { useJUnitPlatform() }
 


### PR DESCRIPTION
## Summary
- add dependencies and tasks to root build script
- expand Makefile with test targets
- add CI workflow for tests
- implement unit tests for booking service and hall renderer
- add integration tests for booking API and waitlist logic
- provide E2E test skeleton with WireMock

## Testing
- `make test-unit` *(fails: Could not resolve jitpack.io)*
- `make test-integration` *(fails: Could not resolve jitpack.io)*
- `make test-e2e` *(fails: Could not resolve jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_688702fd986c8321bff7f7e9d710ee24