### PR TITLE
Add micrometer metrics for Telegram API

### DIFF
--- a/bot-gateway/build.gradle.kts
+++ b/bot-gateway/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation("io.ktor:ktor-server-request-validation:3.2.2")
     implementation(libs.java.jwt)
     implementation("io.micrometer:micrometer-registry-prometheus:1.12.+")
+    implementation("io.micrometer:micrometer-core:1.13.0")
     implementation("io.ktor:ktor-server-micrometer:3.2.2")
     implementation("com.github.zensum:ktor-health-check:0.2.0")
 

--- a/bot-gateway/src/test/kotlin/com/bookingbot/gateway/TelegramApiMetricsTest.kt
+++ b/bot-gateway/src/test/kotlin/com/bookingbot/gateway/TelegramApiMetricsTest.kt
@@ -1,0 +1,36 @@
+package com.bookingbot.gateway
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TelegramApiMetricsTest {
+    @Test
+    fun `metrics recorded`() = runTest {
+        val registry = SimpleMeterRegistry()
+        val orig = TelegramApi.meterRegistry
+        TelegramApi.meterRegistry = registry
+
+        TelegramApi.callTelegram("test") { "ok" }
+        assertFailsWith<RuntimeException> {
+            TelegramApi.callTelegram("test") { throw RuntimeException("boom") }
+        }
+
+        val success = registry.find("telegram_api_requests_total")
+            .tags("method", "test", "status", "success")
+            .counter()!!.count()
+        val error = registry.find("telegram_api_requests_total")
+            .tags("method", "test", "status", "error")
+            .counter()!!.count()
+        val timerCount = registry.find("telegram_api_latency_seconds")
+            .tags("method", "test")
+            .timer()!!.count()
+
+        assertEquals(1.0, success)
+        assertEquals(1.0, error)
+        assertEquals(2, timerCount)
+        TelegramApi.meterRegistry = orig
+    }
+}


### PR DESCRIPTION
## Summary
- add `micrometer-core` dependency
- instrument TelegramApi with counters and timer
- expose registry for tests and wrap API calls in callTelegram
- add unit test verifying metric counts

## Testing
- `./gradlew test` *(fails: SSL initialization errors)*

------
https://chatgpt.com/codex/tasks/task_e_68870c9fa6b483219f27353b8f112b68