### PR TITLE
Add security scanning and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "UTC"
+  - package-ecosystem: "npm"
+    directory: "/admin-panel"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,24 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: '0 4 * * 6'
+
+jobs:
+  deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/gradle-build-action@v3
+        with:
+          arguments: dependencyCheckAnalyze --info
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: build/reports/dependency-check-report.html

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ admin-panel/node_modules/
 detekt-baseline.xml
 !.editorconfig
 
+# OWASP reports
+dependency-check-report.*

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ Services expose Prometheus metrics at `/metrics` and logs in JSON. Grafana is av
 2. For production:
    docker secret create tg_token <(echo "$TELEGRAM_BOT_TOKEN")
    docker compose --env-file .env up -d
+
+## Security automation
+* Dependabot weekly PRs keep Gradle & npm deps up-to-date.
+* OWASP Dependency-Check runs on every PR + Saturday; build fails if CVSS ≥ 7.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 dependencyCheck {
     failBuildOnCVSS = 7.0F
-    suppressionFiles = listOf("dependency-check-suppressions.xml")
+    suppressionFile = "dependency-check-suppressions.xml"
 }
 
 dependencies {
@@ -31,6 +31,8 @@ dependencies {
 }
 
 tasks.test { useJUnitPlatform() }
+
+tasks.named("check") { dependsOn("dependencyCheckAnalyze") }
 
 subprojects {
     apply(plugin = "org.jlleitschuh.gradle.ktlint")


### PR DESCRIPTION
## Summary
- enable Dependabot for Gradle and npm
- run OWASP Dependency Check via workflow
- update build.gradle with Dependency Check config
- document security automation in README
- ignore generated reports

## Testing
- `make test lint` *(fails: Could not resolve dependencies from jitpack)*

------
https://chatgpt.com/codex/tasks/task_e_6887116a2eb08321b19e65473154cf13