### PR TITLE
Fix dependency coordinates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,10 @@ plugins {
     id("io.gitlab.arturbosch.detekt") version "1.23.6" apply false
 }
 
+repositories {
+    mavenCentral()
+}
+
 
 dependencyCheck {
     failBuildOnCVSS = 7.0F

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.9.23"
 ktor = "2.3.8"
-telegrambot = "6.1.0"
+telegram = "6.1.0"
 coroutines = "1.7.3"
 exposed = "0.50.0"
 flyway = "10.14.0"
@@ -22,7 +22,7 @@ caffeine = "3.1.8"
 serializationJson = "1.6.3"
 jedis = "5.2.0"
 embeddedRedis = "0.7.3"
-backoff = "1.2.4"
+backoff = "1.2.3"
 
 [libraries]
 exposed-bom = { module = "org.jetbrains.exposed:exposed-bom", version.ref = "exposed" }
@@ -55,7 +55,7 @@ h2 = { module = "com.h2database:h2", version.ref = "h2" }
 java-jwt = { module = "com.auth0:java-jwt", version.ref = "jwt" }
 koin-ktor = { module = "io.insert-koin:koin-ktor", version.ref = "koin" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
-telegram-bot = { module = "io.github.kotlin-telegram-bot:kotlin-telegram-bot", version.ref = "telegrambot" }
+telegram-bot = { module = "io.github.kotlintelegrambot:telegram", version.ref = "telegram" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "coroutines" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,7 @@ pluginManagement {
     }
 }
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {
         mavenCentral()
     }


### PR DESCRIPTION
## Summary
- update Telegram bot and backoff library coordinates
- keep mavenCentral repo in root Gradle config
- adjust repositoriesMode to allow project repo

## Testing
- `./gradlew :bot-gateway:shadowJar --refresh-dependencies` *(fails: Could not find io.github.kotlintelegrambot:telegram:6.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_688724c0daa88321902b89f713869287