### PR TITLE
Fix bot dependencies

### DIFF
--- a/bot-gateway/build.gradle.kts
+++ b/bot-gateway/build.gradle.kts
@@ -53,10 +53,8 @@ dependencies {
     implementation(libs.koin.logger)
     testImplementation(libs.koin.test)
 
-    // Telegram Bot, без тянущихся артефактов Ktor
-    implementation(libs.telegram.bot) {
-        exclude(group = "io.ktor")
-    }
+    // Telegram Bot
+    implementation(libs.telegram.bot)
 
     // centralized logging backend
     implementation(libs.logback.classic)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,10 +10,6 @@ plugins {
     id("io.gitlab.arturbosch.detekt") version "1.23.6" apply false
 }
 
-repositories {
-    mavenCentral()
-}
-
 
 dependencyCheck {
     failBuildOnCVSS = 7.0F

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.9.23"
 ktor = "2.3.8"
-telegram = "6.1.0"
+telegram = "6.3.0"
 coroutines = "1.7.3"
 exposed = "0.50.0"
 flyway = "10.14.0"
@@ -55,7 +55,7 @@ h2 = { module = "com.h2database:h2", version.ref = "h2" }
 java-jwt = { module = "com.auth0:java-jwt", version.ref = "jwt" }
 koin-ktor = { module = "io.insert-koin:koin-ktor", version.ref = "koin" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
-telegram-bot = { module = "io.github.kotlintelegrambot:telegram", version.ref = "telegram" }
+telegram-bot = { module = "com.github.kotlin-telegram-bot:kotlin-telegram-bot", version.ref = "telegram" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "coroutines" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }
@@ -82,4 +82,4 @@ ktor-metrics = { module = "io.ktor:ktor-server-metrics-micrometer", version.ref 
 koin-logger = { module = "io.insert-koin:koin-logger-slf4j", version.ref = "koin" }
 lettuce = { module = "io.lettuce:lettuce-core", version.ref = "lettuce" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
-backoff = { module = "io.github.reugn:kotlin-backoff", version.ref = "backoff" }
+backoff = { module = "io.github.reugn:kotlin-backoff-coroutines", version.ref = "backoff" }


### PR DESCRIPTION
## Summary
- update libs.versions for telegram bot and backoff
- remove duplicate repo definition
- clean up telegram bot dependency config

## Testing
- `./gradlew build` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68887a714d3c8321a45ff458683b8cb6