### PR TITLE
Fix dependency versions

### DIFF
--- a/bot-gateway/build.gradle.kts
+++ b/bot-gateway/build.gradle.kts
@@ -86,7 +86,7 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5) // Явно указал версию для стабильности
     testImplementation(libs.ktor.client.mock)
     testImplementation("io.mockk:mockk:1.13.9")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+    testImplementation(libs.coroutines.test)
     testImplementation("io.kotest:kotest-runner-junit5-jvm:5.9.0")
     testImplementation("io.kotest:kotest-assertions-core-jvm:5.9.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     // --- unit ---
     testImplementation("io.mockk:mockk:1.13.9")
     testImplementation("io.kotest:kotest-assertions-core:5.8.1")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+    testImplementation(libs.coroutines.test)
 
     // --- integration ---
     testImplementation("io.ktor:ktor-server-test-host:2.3.+")
@@ -28,7 +28,7 @@ dependencies {
     testImplementation("com.h2database:h2:2.2.224")
 
     // --- E2E ---
-    testImplementation("com.github.tomakehurst:wiremock-jre8:3.3.1")
+    testImplementation(libs.wiremock)
 }
 
 tasks.test { useJUnitPlatform() }

--- a/fix_build.sh
+++ b/fix_build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+./gradlew clean build --refresh-dependencies --info

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 kotlin.code.style=official
 
-kotlinVersion=1.9.23
+kotlinVersion=1.9.24
 ktorVersion=2.3.12
 telegramBotVersion=6.1.0
-coroutinesVersion=1.7.3
+coroutinesVersion=1.8.1
 exposedVersion=0.50.0
-flywayVersion=10.14.0
-postgresVersion=42.7.3
+flywayVersion=10.15.0
+postgresVersion=42.7.7
 org.gradle.java.installations.auto-download=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,28 +1,28 @@
 [versions]
-kotlin = "1.9.23"
-ktor = "2.3.8"
+kotlin = "1.9.24"
+ktor = "2.3.12"
 telegram = "6.1.0"
-coroutines = "1.7.3"
+coroutines = "1.8.1"
 exposed = "0.50.0"
-flyway = "10.14.0"
-postgres = "42.7.3"
-hikaricp = "5.0.1"
+flyway = "10.15.0"
+postgres = "42.7.7"
+hikaricp = "6.3.0"
 config = "1.4.3"
 dotenv = "6.3.1"
-logback = "1.4.11"
+logback = "1.5.18"
 koin = "3.5.6"
 jwt = "4.4.0"
 h2 = "2.1.214"
-junit = "5.10.0"
-mockito = "5.9.0"
-mockitoKotlin = "5.2.1"
-wiremock = "3.3.1"
-lettuce = "6.3.2.RELEASE"
-caffeine = "3.1.8"
-serializationJson = "1.6.3"
-jedis = "5.2.0"
+junit = "5.10.2"
+mockito = "5.18.0"
+mockitoKotlin = "5.4.0"
+wiremock = "3.0.1"
+lettuce = "6.7.1.RELEASE"
+caffeine = "3.2.0"
+serializationJson = "1.9.0"
+jedis = "6.0.0"
 embeddedRedis = "0.7.3"
-backoff = "1.2.3"
+backoff = "0.4.0"
 
 [libraries]
 exposed-bom = { module = "org.jetbrains.exposed:exposed-bom", version.ref = "exposed" }
@@ -82,4 +82,4 @@ ktor-metrics = { module = "io.ktor:ktor-server-metrics-micrometer", version.ref 
 koin-logger = { module = "io.insert-koin:koin-logger-slf4j", version.ref = "koin" }
 lettuce = { module = "io.lettuce:lettuce-core", version.ref = "lettuce" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
-backoff = { module = "com.github.reugn:kotlin-backoff-coroutines", version.ref = "backoff" }
+backoff = { module = "io.github.reugn:kotlin-backoff", version.ref = "backoff" }


### PR DESCRIPTION
## Summary
- update library versions in version catalog
- set latest patch versions in gradle.properties
- switch to library aliases in Gradle scripts
- add helper script `fix_build.sh`

## Testing
- `./gradlew build --refresh-dependencies --info` *(fails: Could not get resource https://jitpack.io/... telegram-6.1.0.pom)*

------
https://chatgpt.com/codex/tasks/task_e_688a632ef4bc8321874a46df03a2715d