### PR TITLE
fix: resolve EntityID type inference

### DIFF
--- a/booking-api/src/main/kotlin/com/bookingbot/api/services/TableService.kt
+++ b/booking-api/src/main/kotlin/com/bookingbot/api/services/TableService.kt
@@ -35,7 +35,7 @@ class TableService {
         val operationalNightEnd = localBookingDate.plusDays(1).atTime(12, 0).atZone(ZoneId.systemDefault()).toInstant()
 
         // 3. Находим ID всех столов, которые уже забронированы на эту ночь
-        val bookedTableIds = BookingsTable
+        val bookedTableIds: Set<Int> = BookingsTable
             .select {
                 (BookingsTable.clubId eq clubId) and
                         (BookingsTable.status inList listOf("PENDING", "SEATED")) and
@@ -93,7 +93,7 @@ class TableService {
      * Calculates deposit amount for given table and guest count.
      */
     fun calculateDeposit(tableId: Int, guestCount: Int): BigDecimal = transaction {
-        val depositPerGuest = TablesTable
+        val depositPerGuest: BigDecimal = TablesTable
             .select { TablesTable.id eq tableId }
             .map { it[TablesTable.minDeposit] }
             .singleOrNull() ?: BigDecimal.ZERO

--- a/booking-api/src/main/kotlin/com/bookingbot/api/services/WaitlistDao.kt
+++ b/booking-api/src/main/kotlin/com/bookingbot/api/services/WaitlistDao.kt
@@ -9,7 +9,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 /** DAO for waiting_list operations. */
 object WaitlistDao {
     fun addEntry(chatId: Long, desiredTime: java.time.Instant, preferredTable: Int?): WaitEntry = transaction {
-        val id = WaitlistTable.insertAndGetId {
+        val id: Int = WaitlistTable.insertAndGetId {
             it[WaitlistTable.chatId] = chatId
             it[WaitlistTable.desiredTime] = desiredTime
             it[WaitlistTable.preferredTable] = preferredTable
@@ -18,15 +18,17 @@ object WaitlistDao {
     }
 
     fun getEntry(id: Int): WaitEntry? = transaction {
-        WaitlistTable.select { WaitlistTable.id eq id }
+        val entry: WaitEntry? = WaitlistTable.select { WaitlistTable.id eq id }
             .map { it.toWaitEntry() }
             .singleOrNull()
+        entry
     }
 
     fun findActive(): List<WaitEntry> = transaction {
-        WaitlistTable
+        val entries: List<WaitEntry> = WaitlistTable
             .select { WaitlistTable.status eq "ACTIVE" }
             .map { it.toWaitEntry() }
+        entries
     }
 
     fun updateStatus(id: Int, status: String) = transaction {


### PR DESCRIPTION
## Summary
- avoid EntityID generics ambiguity when mapping table availability
- specify concrete numeric types for table queries and waitlist entries

## Testing
- `./gradlew -p booking-api clean build`


------
https://chatgpt.com/codex/tasks/task_e_6890bb83749c8321948a3778ae24ce5f