### PR TITLE
chore: configure explicit junit tests

### DIFF
--- a/booking-api/build.gradle.kts
+++ b/booking-api/build.gradle.kts
@@ -35,15 +35,13 @@ dependencies {
     implementation("io.insert-koin:koin-logger-slf4j:3.4.0")
 
     // Test dependencies
+    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("io.ktor:ktor-server-tests:2.3.0")
-    testImplementation(kotlin("test"))
+    testImplementation(kotlin("test-junit5"))
     testImplementation("org.testcontainers:postgresql:1.18.1")
     testImplementation("org.testcontainers:junit-jupiter:1.18.1")
     testImplementation("io.mockk:mockk:1.13.5")
     testImplementation("com.h2database:h2:2.1.214")
-}
-
-tasks.test {
-    useJUnitPlatform()
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,3 +2,9 @@ plugins {
     kotlin("jvm") version "1.9.24" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "1.9.24" apply false
 }
+
+subprojects {
+    tasks.withType<Test> {
+        useJUnitPlatform()
+    }
+}


### PR DESCRIPTION
## Summary
- ensure all subprojects use JUnit Platform
- add explicit JUnit 5 dependencies for booking-api tests

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6890cefc78f88321af711c5369440b39