### PR TITLE
feat: add entrance manager guest check-in

### DIFF
--- a/booking-api/src/main/kotlin/com/bookingbot/api/model/GuestListEntry.kt
+++ b/booking-api/src/main/kotlin/com/bookingbot/api/model/GuestListEntry.kt
@@ -5,5 +5,6 @@ data class GuestListEntry(
     val clubId: Int,
     val promoterId: Long,
     val firstName: String,
-    val lastName: String
+    val lastName: String,
+    val checkedIn: Boolean
 )

--- a/booking-api/src/main/kotlin/com/bookingbot/api/services/GuestListService.kt
+++ b/booking-api/src/main/kotlin/com/bookingbot/api/services/GuestListService.kt
@@ -4,6 +4,7 @@ import com.bookingbot.api.model.GuestListEntry
 import com.bookingbot.api.tables.GuestListTable
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.update
 import org.jetbrains.exposed.sql.transactions.transaction
 
 class GuestListService(private val clubService: ClubService) {
@@ -28,8 +29,15 @@ class GuestListService(private val clubService: ClubService) {
                 clubId = it[GuestListTable.clubId],
                 promoterId = it[GuestListTable.promoterId],
                 firstName = it[GuestListTable.firstName],
-                lastName = it[GuestListTable.lastName]
+                lastName = it[GuestListTable.lastName],
+                checkedIn = it[GuestListTable.checkedIn]
             )
         }
+    }
+
+    fun checkInGuest(guestId: Int): Boolean = transaction {
+        GuestListTable.update({ GuestListTable.id eq guestId }) {
+            it[checkedIn] = true
+        } > 0
     }
 }

--- a/booking-api/src/main/kotlin/com/bookingbot/api/tables/GuestListTable.kt
+++ b/booking-api/src/main/kotlin/com/bookingbot/api/tables/GuestListTable.kt
@@ -7,4 +7,5 @@ object GuestListTable : IntIdTable("guest_list") {
     val promoterId = long("promoter_id").references(UsersTable.telegramId)
     val firstName = varchar("first_name", 100)
     val lastName = varchar("last_name", 100)
+    val checkedIn = bool("checked_in").default(false)
 }

--- a/booking-api/src/main/resources/db/migration/V9__AddCheckedInToGuestList.sql
+++ b/booking-api/src/main/resources/db/migration/V9__AddCheckedInToGuestList.sql
@@ -1,0 +1,4 @@
+ALTER TABLE guest_list
+    ADD COLUMN IF NOT EXISTS checked_in BOOLEAN DEFAULT FALSE;
+CREATE INDEX IF NOT EXISTS idx_guest_list_checked_in ON guest_list(checked_in);
+

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Bot.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/Bot.kt
@@ -93,6 +93,7 @@ object Bot {
             addAskQuestionHandler(this, clubService)
             addAdminHandlers(this, userService, clubService)
             addPromoterHandlers(this, userService, clubService, guestListService)
+            addEntranceManagerHandlers(this, userService, guestListService)
             addAdminActionHandler(this, bookingService, clubService)
             addContentHandlers(this)
             addTablesHandler(this, bookingService)

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/entranceManagerHandlers.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/entranceManagerHandlers.kt
@@ -1,0 +1,65 @@
+package com.bookingbot.gateway.handlers
+
+import com.bookingbot.gateway.TelegramApi
+import com.bookingbot.gateway.markup.Menus
+import com.bookingbot.gateway.util.CallbackData
+import com.bookingbot.api.services.GuestListService
+import com.bookingbot.api.services.UserService
+import com.github.kotlintelegrambot.dispatcher.Dispatcher
+import com.github.kotlintelegrambot.dispatcher.callbackQuery
+import com.github.kotlintelegrambot.entities.ChatId
+import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
+import com.github.kotlintelegrambot.entities.keyboard.InlineKeyboardButton
+
+fun addEntranceManagerHandlers(dispatcher: Dispatcher, userService: UserService, guestListService: GuestListService) {
+
+    fun sendGuestList(managerId: Long, clubId: Int) {
+        val guests = guestListService.getGuestsForClub(clubId)
+        if (guests.isEmpty()) {
+            TelegramApi.sendMessage(ChatId.fromId(managerId), "Список гостей пуст.")
+            return
+        }
+        val rows = guests.map { guest ->
+            val status = if (guest.checkedIn) "✅" else "❌"
+            listOf(
+                InlineKeyboardButton.CallbackData(
+                    text = "$status ${guest.firstName} ${guest.lastName}",
+                    callbackData = "${CallbackData.ENTRANCE_CHECKIN_PREFIX}${guest.id}"
+                )
+            )
+        } + listOf(listOf(Menus.backToMainMenuButton))
+        TelegramApi.sendMessage(
+            chatId = ChatId.fromId(managerId),
+            text = "Список гостей:",
+            replyMarkup = InlineKeyboardMarkup.create(rows)
+        )
+    }
+
+    dispatcher.callbackQuery(CallbackData.ENTRANCE_GUESTS) {
+        val managerId = callbackQuery.from.id
+        val clubId = userService.getStaffClubId(managerId)
+        if (clubId == null) {
+            bot.answerCallbackQuery(callbackQuery.id, text = "Вы не привязаны к клубу.", showAlert = true)
+            return@callbackQuery
+        }
+        sendGuestList(managerId, clubId)
+    }
+
+    dispatcher.callbackQuery {
+        val data = callbackQuery.data ?: return@callbackQuery
+        if (data.startsWith(CallbackData.ENTRANCE_CHECKIN_PREFIX)) {
+            val guestId = data.removePrefix(CallbackData.ENTRANCE_CHECKIN_PREFIX).toInt()
+            val managerId = callbackQuery.from.id
+            val clubId = userService.getStaffClubId(managerId)
+            if (clubId == null) {
+                bot.answerCallbackQuery(callbackQuery.id, text = "Вы не привязаны к клубу.", showAlert = true)
+                return@callbackQuery
+            }
+            val success = guestListService.checkInGuest(guestId)
+            val text = if (success) "Гость отмечен как прошедший." else "Гость не найден."
+            bot.answerCallbackQuery(callbackQuery.id, text = text, showAlert = true)
+            sendGuestList(managerId, clubId)
+        }
+    }
+}
+

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/promoterHandlers.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/promoterHandlers.kt
@@ -25,7 +25,7 @@ fun addPromoterHandlers(dispatcher: Dispatcher, userService: UserService, clubSe
         val promoter = userService.findOrCreateUser(promoterId, callbackQuery.from.username)
 
         // Проверяем, что у пользователя роль промоутера
-        if (promoter.role != UserRole.PROMOTER && promoter.role != UserRole.OWNER) {
+        if (promoter.role != UserRole.PROMOTER && promoter.role != UserRole.OWNER && promoter.role != UserRole.ENTRANCE_MANAGER) {
             bot.answerCallbackQuery(callbackQuery.id, text = "Эта функция доступна только для промоутеров.", showAlert = true)
             return@callbackQuery
         }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/startHandler.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/handlers/startHandler.kt
@@ -17,7 +17,7 @@ fun addStartHandler(dispatcher: Dispatcher, userService: UserService) {
             UserRole.PROMOTER -> "Панель промоутера. Выберите действие:" to Menus.promoterMenu()
             UserRole.ADMIN -> "Панель администратора. Выберите действие:" to Menus.adminMenu()
             UserRole.OWNER -> "Панель владельца. Выберите действие:" to Menus.adminMenu() // Владелец пока использует меню админа
-            UserRole.ENTRANCE_MANAGER -> "Панель менеджера входа. Выберите действие:" to Menus.adminMenu()
+            UserRole.ENTRANCE_MANAGER -> "Панель менеджера входа. Выберите действие:" to Menus.entranceManagerMenu()
         }
 
         TelegramApi.sendMessage(

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/markup/Menus.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/markup/Menus.kt
@@ -51,4 +51,14 @@ object Menus {
             )
         )
     }
+
+    fun entranceManagerMenu(): InlineKeyboardMarkup {
+        return InlineKeyboardMarkup.create(
+            listOf(
+                listOf(InlineKeyboardButton.CallbackData(text = "Список гостей", callbackData = CallbackData.ENTRANCE_GUESTS)),
+                listOf(InlineKeyboardButton.CallbackData(text = "Бронь для гостя", callbackData = CallbackData.PROMOTER_START_BOOKING)),
+                listOf(backToMainMenuButton)
+            )
+        )
+    }
 }

--- a/bot-gateway/src/main/kotlin/com/bookingbot/gateway/util/CallbackData.kt
+++ b/bot-gateway/src/main/kotlin/com/bookingbot/gateway/util/CallbackData.kt
@@ -15,6 +15,9 @@ object CallbackData {
     const val PROMOTER_ADD_GUEST = "promoter_add_guest"
     const val PROMOTER_GUESTLIST_CLUB_PREFIX = "promoter_guestlist_club_"
 
+    const val ENTRANCE_GUESTS = "entrance_guests"
+    const val ENTRANCE_CHECKIN_PREFIX = "entrance_checkin_"
+
     const val BROADCAST_CONFIRM_SEND = "broadcast_confirm_send"
     const val BROADCAST_CANCEL = "broadcast_cancel"
 


### PR DESCRIPTION
## Summary
- allow tracking guest check-ins with a new `checked_in` column and service API
- add entrance manager menu/handlers to view guest list and mark arrivals
- permit entrance managers to start guest table bookings

## Testing
- `./gradlew test` *(fails: Could not resolve io.github.kotlin-telegram-bot.kotlin-telegram-bot:telegram:6.1.7)*
- `./gradlew :booking-api:test` *(fails: compilation error in tests - unresolved reference to test helpers)*

------
https://chatgpt.com/codex/tasks/task_e_6896b72d9dd08321bf7df9446566ff8a